### PR TITLE
fix: Support --tags and --tag=value syntax for CLI tag flags

### DIFF
--- a/features/tagging.feature
+++ b/features/tagging.feature
@@ -45,3 +45,21 @@ Feature: Document Tagging
     And the file "test_docs/notes/note_merged_tags_note.md" should contain "- sprint-42"
     And the file "test_docs/notes/note_merged_tags_note.md" should contain "- infrastructure"
     And the file "test_docs/notes/note_merged_tags_note.md" should contain "- monitoring"
+
+  Scenario: Create document with --tag=value syntax
+    When I run `bundle exec dia explanation new "Equals Tagged" --tag=backend`
+    Then the exit status should be 0
+    And the file "test_docs/explanations/explanation_equals_tagged.md" should contain "tags:"
+    And the file "test_docs/explanations/explanation_equals_tagged.md" should contain "- backend"
+
+  Scenario: Create document with --tags=value syntax (plural)
+    When I run `bundle exec dia explanation new "Plural Tagged" --tags=frontend`
+    Then the exit status should be 0
+    And the file "test_docs/explanations/explanation_plural_tagged.md" should contain "tags:"
+    And the file "test_docs/explanations/explanation_plural_tagged.md" should contain "- frontend"
+
+  Scenario: Create document with --tags space-separated value
+    When I run `bundle exec dia explanation new "Space Tagged" --tags api`
+    Then the exit status should be 0
+    And the file "test_docs/explanations/explanation_space_tagged.md" should contain "tags:"
+    And the file "test_docs/explanations/explanation_space_tagged.md" should contain "- api"

--- a/lib/diataxis/cli/global_flags_handler.rb
+++ b/lib/diataxis/cli/global_flags_handler.rb
@@ -18,9 +18,11 @@ module Diataxis
             Diataxis.logger.debug('Verbose mode enabled')
           when '--quiet', '-q'
             Diataxis::Log.level = Logger::WARN
-          when '--tag', '-t'
+          when '--tag', '--tags', '-t'
             i += 1
             tags << args[i] if i < args.length
+          when /\A--tags?=(.*)\z/
+            tags << Regexp.last_match(1) unless Regexp.last_match(1).empty?
           else
             remaining << args[i]
           end


### PR DESCRIPTION
## Summary

- **Bug:** Using `--tags` (plural) or `--tag=value` / `--tags=value` (equals syntax) caused the tag string to be treated as a regular argument, embedding it in the filename instead of the YAML front matter
- **Fix:** Added `--tags` as a synonym for `--tag` in the space-separated branch, and added a regex match for `--tag=value` and `--tags=value` inline syntax in `GlobalFlagsHandler`
- **Tests:** Added 3 Cucumber scenarios covering `--tag=value`, `--tags=value`, and `--tags <value>` syntax

## Verified

- 46 RSpec examples pass
- 36 Cucumber scenarios (251 steps) pass, including the 3 new tagging scenarios
- `DIATAXIS_TAG` environment variable continues to work correctly (handled independently via `parse_env_tags`, merged and deduplicated with CLI tags)

## Test plan

- [x] `bundle exec rspec` — all 46 examples pass
- [x] `bundle exec cucumber` — all 36 scenarios pass
- [x] Verify `DIATAXIS_TAG` env var still works (existing scenarios pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)