### PR TITLE
fix: Rename DIATAXIS_TAG to DIATAXIS_TAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Diataxis is a command-line tool for managing documentation following the [Diatax
 * Recursive document discovery in subdirectories
 * Configurable directory structure via `.diataxis` config file
 * `DIATAXIS_ROOT` environment variable for running `dia` from any directory
-* `--tag`/`-t` flags and `DIATAXIS_TAG` for attaching YAML front matter tags at creation time
+* `--tag`/`-t` flags and `DIATAXIS_TAGS` for attaching YAML front matter tags at creation time
 * Shared metadata guidelines injected into templates via `{{common.metadata}}`
 * Maintains alphabetical order in documentation lists
 
@@ -69,18 +69,18 @@ When `DIATAXIS_ROOT` is set, all operations — `init`, document creation, and `
 
 ### Tagging Documents
 
-Attach tags to generated documents as YAML front matter using `--tag`/`-t` flags or the `DIATAXIS_TAG` environment variable:
+Attach tags to generated documents as YAML front matter using `--tag`/`-t` flags or the `DIATAXIS_TAGS` environment variable:
 
 ```bash
 # CLI flags (repeatable)
 dia explanation new "API Design" --tag backend -t api
 
 # Environment variable (comma-separated)
-export DIATAXIS_TAG="sprint-42, backend"
-dia howto new "Configure Redis"                         # inherits tags from DIATAXIS_TAG
+export DIATAXIS_TAGS="sprint-42, backend"
+dia howto new "Configure Redis"                         # inherits tags from DIATAXIS_TAGS
 
 # Both sources are merged and deduplicated
-DIATAXIS_TAG="backend" dia note new "Redis Notes" -t api
+DIATAXIS_TAGS="backend" dia note new "Redis Notes" -t api
 # Result front matter: tags: [backend, api]
 ```
 
@@ -159,7 +159,7 @@ Everyone interacting in the Diataxis project's codebases, issue trackers, chat r
 * [ADR-0012](docs/adr/0012-move-to-external-template-system-with-direct-templateloader-usage.md) - Move to External Template System with Direct TemplateLoader Usage
 * [ADR-0013](docs/adr/0013-set-default-directory-for-all-templates.md) - Set default directory for all templates
 * [ADR-0014](docs/adr/0014-underscore-the-gtd-directory-for-project-files-so-they-always-live-at-the-top.md) - Underscore the gtd directory for project files so they always live at the top
-* [ADR-0015](docs/adr/0015-support-environment-variable-configuration-with-diataxis-root-and-diataxis-tag.md) - Support environment variable configuration with DIATAXIS_ROOT and DIATAXIS_TAG
+* [ADR-0015](docs/adr/0015-support-environment-variable-configuration-with-diataxis-root-and-diataxis-tags.md) - Support environment variable configuration with DIATAXIS_ROOT and DIATAXIS_TAGS
 * [ADR-0016](docs/adr/0016-replace-per-type-class-files-with-registry-dsl-and-template-method-hooks.md) - Replace per-type class files with registry DSL and template method hooks
 <!-- adrlogstop -->
 

--- a/docs/adr/0015-support-environment-variable-configuration-with-diataxis-root-and-diataxis-tags.md
+++ b/docs/adr/0015-support-environment-variable-configuration-with-diataxis-root-and-diataxis-tags.md
@@ -1,4 +1,4 @@
-# 0015. Support environment variable configuration with DIATAXIS_ROOT and DIATAXIS_TAG
+# 0015. Support environment variable configuration with DIATAXIS_ROOT and DIATAXIS_TAGS
 
 Date: 2026-05-02
 
@@ -27,10 +27,10 @@ Support environment-variable-based configuration alongside CLI flags, following 
 - When unset or empty, behaviour is unchanged — `pwd` is used as before
 - An explicit directory argument (e.g., `dia update /some/path`) still overrides `DIATAXIS_ROOT`
 
-### DIATAXIS_TAG and --tag/-t
+### DIATAXIS_TAGS and --tag/-t
 
 - `--tag TAG` (or `-t TAG`) attaches one or more tags to a generated document's YAML front matter
-- `DIATAXIS_TAG` accepts a comma-separated list of tags (e.g., `DIATAXIS_TAG="sprint-42, auth"`)
+- `DIATAXIS_TAGS` accepts a comma-separated list of tags (e.g., `DIATAXIS_TAGS="sprint-42, auth"`)
 - Tags from both sources are merged and deduplicated; CLI flags take precedence over env var
 - When no tags are specified, no YAML front matter is added — existing behaviour is preserved exactly
 
@@ -59,4 +59,4 @@ Support environment-variable-based configuration alongside CLI flags, following 
 
 - [ADR-0002: Use Configuration File for Document Paths](./0002-use-configuration-file-for-document-paths.md) — the original config file decision that this extends
 - [ADR-0013: Set default directory for all templates](./0013-set-default-directory-for-all-templates.md) — the prior directory default decision
-- [PR: Add DIATAXIS_ROOT, --tag/-t, and DIATAXIS_TAG support](../pr_add_diataxis_root_tag_t_and_diataxis_tag_environment_variable_support.md) — implementation details
+- [PR: Add DIATAXIS_ROOT, --tag/-t, and DIATAXIS_TAGS support](../pr_add_diataxis_root_tag_t_and_diataxis_tag_environment_variable_support.md) — implementation details

--- a/features/tagging.feature
+++ b/features/tagging.feature
@@ -31,15 +31,15 @@ Feature: Document Tagging
     Then the exit status should be 0
     And the file "test_docs/explanations/explanation_untagged_document.md" should not contain "tags:"
 
-  Scenario: Tags from DIATAXIS_TAG environment variable
-    Given I set the environment variable "DIATAXIS_TAG" to "sprint-42, infrastructure"
+  Scenario: Tags from DIATAXIS_TAGS environment variable
+    Given I set the environment variable "DIATAXIS_TAGS" to "sprint-42, infrastructure"
     When I run `bundle exec dia note new "Env Tagged Note"`
     Then the exit status should be 0
     And the file "test_docs/notes/note_env_tagged_note.md" should contain "- sprint-42"
     And the file "test_docs/notes/note_env_tagged_note.md" should contain "- infrastructure"
 
   Scenario: Merge CLI and env tags with deduplication
-    Given I set the environment variable "DIATAXIS_TAG" to "sprint-42, infrastructure"
+    Given I set the environment variable "DIATAXIS_TAGS" to "sprint-42, infrastructure"
     When I run `bundle exec dia note new "Merged Tags Note" --tag infrastructure -t monitoring`
     Then the exit status should be 0
     And the file "test_docs/notes/note_merged_tags_note.md" should contain "- sprint-42"

--- a/lib/diataxis/cli/global_flags_handler.rb
+++ b/lib/diataxis/cli/global_flags_handler.rb
@@ -37,7 +37,7 @@ module Diataxis
       end
 
       private_class_method def self.parse_env_tags
-        value = ENV.fetch('DIATAXIS_TAG', nil)
+        value = ENV.fetch('DIATAXIS_TAGS', nil)
         return [] if value.nil? || value.strip.empty?
 
         value.split(',').map(&:strip).reject(&:empty?)

--- a/lib/diataxis/cli/usage_display.rb
+++ b/lib/diataxis/cli/usage_display.rb
@@ -46,7 +46,7 @@ module Diataxis
           #{'  '}
           Environment Variables:
             DIATAXIS_ROOT             - Root directory for dia commands (overrides CWD)
-            DIATAXIS_TAG              - Default tags, comma-separated (e.g. "-foo,-bar")
+            DIATAXIS_TAGS             - Default tags, comma-separated (e.g. "-foo,-bar")
             DIATAXIS_LOG_LEVEL        - Set log level (DEBUG, INFO, WARN, ERROR, FATAL)
             DIATAXIS_QUIET            - Set to 'true' to suppress output
         USAGE

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -745,9 +745,9 @@ RSpec.describe Diataxis do
     end
   end
 
-  describe '--tag / -t flag and DIATAXIS_TAG' do
+  describe '--tag / -t flag and DIATAXIS_TAGS' do
     after do
-      ENV.delete('DIATAXIS_TAG')
+      ENV.delete('DIATAXIS_TAGS')
     end
 
     it 'creates document with YAML front matter tags from CLI flags' do
@@ -763,8 +763,8 @@ RSpec.describe Diataxis do
       expect(content).to include('  - -jira/bolt/141')
     end
 
-    it 'creates document with tags from DIATAXIS_TAG env var' do
-      ENV['DIATAXIS_TAG'] = '-env/tag1,-env/tag2'
+    it 'creates document with tags from DIATAXIS_TAGS env var' do
+      ENV['DIATAXIS_TAGS'] = '-env/tag1,-env/tag2'
 
       Dir.chdir(test_dir) do
         Diataxis::CLI.run(['note', 'new', 'Env Tagged'])
@@ -777,8 +777,8 @@ RSpec.describe Diataxis do
       expect(content).to include('  - -env/tag2')
     end
 
-    it 'merges CLI tags with DIATAXIS_TAG and deduplicates' do
-      ENV['DIATAXIS_TAG'] = '-shared,-env-only'
+    it 'merges CLI tags with DIATAXIS_TAGS and deduplicates' do
+      ENV['DIATAXIS_TAGS'] = '-shared,-env-only'
 
       Dir.chdir(test_dir) do
         Diataxis::CLI.run(['-t', '-shared', '-t', '-cli-only', 'howto', 'new', 'Merged Tags'])
@@ -793,7 +793,7 @@ RSpec.describe Diataxis do
     end
 
     it 'creates document without front matter when no tags provided' do
-      ENV.delete('DIATAXIS_TAG')
+      ENV.delete('DIATAXIS_TAGS')
 
       Dir.chdir(test_dir) do
         Diataxis::CLI.run(['explanation', 'new', 'No Tags'])

--- a/templates/common.metadata
+++ b/templates/common.metadata
@@ -15,6 +15,7 @@
 **Linking Rules:**
 - Every reference in Related Topics must be a real link (no placeholder bullets).
 - **Code**: Link to GitHub with line numbers: [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123).
+- **Commits**: Link to the actual commit: [`short-sha`](https://github.com/org/repo/commit/full-sha). In PR descriptions, each change section must include a commit link so reviewers can navigate directly to the diff.
 - **Docs**: Link to official documentation pages.
 - **Local**: Link to local docs with relative paths.
 


### PR DESCRIPTION
## Summary

- Renames `DIATAXIS_TAG` environment variable to `DIATAXIS_TAGS` (plural) since it holds a comma-separated list
- Updates all code, tests (RSpec + Cucumber), README, help text, and ADR-0015
- No change to `--tag`/`-t` CLI flags, tag parsing logic, or any other behaviour

## Background

A user setting `DIATAXIS_TAGS` in their `.envrc` found it silently ignored because the code read `DIATAXIS_TAG`. The plural form better communicates that the variable accepts multiple comma-separated values.

## Changes
> Commit: [`dd633ff`](https://github.com/gavindidrichsen/diataxis/pull/38/changes/dd633ff2e04b88036340ce93731c7a47281ea054)

All code, test, and documentation references updated.  See the commit for more details
