### PR TITLE
fix: Remove "Project:" prefix from project template title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ coverage/
 .cache/
 tmp/
 docs/gsd/
+.agents/
+skills-lock.json

--- a/templates/references/project.md
+++ b/templates/references/project.md
@@ -42,7 +42,7 @@ Core Principles:
 (No additional template-specific guidelines.)
 -->
 
-# Project: {{title}}
+# {{title}}
 
 **@urgent** tasks:
 


### PR DESCRIPTION
## Summary

- Removes the `Project: ` prefix from the H1 title in `templates/references/project.md`, so new project docs render as `# {{title}}` like every other template.
- Fixes the `dia update` doubling bug: previously the title round-tripped as `"Project: <title>"`, which got slugified and re-prefixed with `project_`, producing `project_project_<title>.md` filenames.
- Also includes an earlier commit (`cf814f9`) adding gsd artifacts to `.gitignore`.

Closes #31.

## Test plan

- [ ] `dia project new "Inbox"` creates a file whose H1 is `# Inbox` (not `# Project: Inbox`).
- [ ] `dia update .` on a freshly created project doc leaves the filename as `project_inbox.md` (no doubling).
- [ ] Note: pre-existing project docs still containing `# Project: <title>` will need their H1 manually normalized before `dia update`, or they'll rename to `project_project_*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)