### PR TITLE
Reshape project template to handover structure; standardize "Related Topics" across templates

### DIFF
--- a/templates/references/5why.md
+++ b/templates/references/5why.md
@@ -39,6 +39,6 @@ Key commands used during investigation:
 # command examples
 ```
 
-## References
+## Related Topics
 
 - Issue trackers, code, documentation, and local docs links go here.

--- a/templates/references/adr.md
+++ b/templates/references/adr.md
@@ -28,6 +28,6 @@ What is the change that we're proposing and/or doing?
 
 What becomes easier or more difficult to do because of this change?
 
-## References
+## Related Topics
 
 - Related ADRs, code, documentation, and local docs links go here.

--- a/templates/references/handover.md
+++ b/templates/references/handover.md
@@ -51,6 +51,6 @@ Research suggestions:
 # useful commands for investigation
 ```
 
-## References
+## Related Topics
 
 - Code, documentation, issue trackers, and local docs links go here.

--- a/templates/references/note.md
+++ b/templates/references/note.md
@@ -8,24 +8,24 @@
 
 # {{title}}
 
-## KEYPOINTS
+## Keypoints
 
 * Add a concise summary here of the context
 * Add simple list of steps to achieve the goal of this note. For example, a bulleted list or if it is code or bash command-line work, then add a single ```bash...``` code block with the commands required to either replicate the problem, solve the problem, etc.
 
-## SUMMARY
+## Summary
 
 * Add a more detailed summary with code snippets of logs extracts, etc.
-* This section should enhance the KEYPOINTS section.
+* This section should enhance the Keypoints section.
 
-## TASKS
+## Tasks
 
 This section should hold any outstanding tasks that I might want to re-visit. Only if this is relevant. Always ask me if I want to add ones that you propose. If I say to add a task, then add it here.
 
-## BACKGROUND
+## Background
 
 I used this section to keep a running breadcrumb trail of what I've been doing
 
-## REFERENCES
+## Related Topics
 
 - Code, documentation, and local docs links go here.

--- a/templates/references/project.md
+++ b/templates/references/project.md
@@ -1,86 +1,113 @@
 <!--
-GTD Philosophy Overview
-
-Getting Things Done (GTD) is a productivity methodology by David Allen designed to reduce 
-stress and improve clarity by organizing tasks and commitments into actionable lists.
-
-Core Principles:
-
-1. Capture Everything
-   Collect all tasks, ideas, and commitments into a trusted system so nothing stays in your head.
-
-2. Clarify & Organize
-   Decide what each item means and where it belongs:
-   - Is it actionable?
-   - If yes, what's the Next Action?
-   - If no, trash it, incubate it, or file it as reference.
-
-3. Next Action Thinking
-   Break projects into the very next physical, visible step you can take to move it forward.
-   Example: Instead of "Plan website redesign," write "Email designer to schedule kickoff."
-
-4. Project Definition
-   A project in GTD is any outcome requiring more than one action. Define:
-   - Purpose (Why this matters)
-   - Desired Outcome (What "done" looks like)
-   - Next Actions (What to do now)
-
-5. Contextual Lists
-   Organize actions by context or state:
-   - @waiting – tasks dependent on others
-   - @backlog – deferred tasks
-   - @someday – ideas for the future
-
-6. Review Regularly
-   Weekly review ensures clarity and trust in your system.
--->
-<!--
 # Common Guidelines
 {{common.metadata}}
 
 # Template-Specific Guidelines
-(No additional template-specific guidelines.)
+Project doc — a project is any outcome needing more than one action.
+
+Shape: open by capturing your thinking (handover style — problem, what we know,
+what we think), then a sparse Next Actions checklist, with the supporting detail pushed
+down into a Key Concepts section (explanation style). Each task assumes the
+reader already knows what it means and links to its Key Concept for the "what
+does this actually mean / what are the options" detail. This keeps the task list
+lovely and clear without losing the depth a reviewer needs.
+
+Sections:
+- Problem            — the problem in one line + what "done" looks like in one line
+  - What we know     — (### subsection) confirmed facts / current state, with evidence
+  - What we think    — (### subsection) hypotheses, or the chosen plan and the reasoning for it
+- Next Actions       — @urgent items, one line each, each linking to a Key Concept
+- Key Concepts       — the meat behind the actions (mechanisms, decisions, jargon)
+- Background         — running breadcrumb of decisions made and progress so far
+- Related Topics     — real links to code, docs, tickets, and local notes
+
+**Problem section:**
+- Lead with two bold lines: **Problem:** (one line) and **Done looks like:** (one line).
+- Then two `###` subsections — **What we know** and **What we think** (see below).
+- This is the orientation. Keep the leads to one sentence each — depth belongs lower down.
+
+**What we know / What we think:**
+- "What we know" = confirmed, evidenced facts and current state — link evidence
+  (code lines, logs, command output) rather than asserting.
+- "What we think" = hypotheses or the chosen plan, each with its reasoning. This
+  is where judgement lives; mark anything unconfirmed as such.
+- If a project has no open thinking (pure delivery), keep "What we think" short
+  — a one-line statement of the plan is fine — but do not delete the heading.
+
+**Next Actions ↔ Key Concept linking:**
+- Next Actions is a bare `@urgent` checklist — one line per item, with **no
+  intro or explanatory line above it** (that rule lives here, not in the body).
+- Each item is sparse and skimmable; assume the reader knows the terms.
+- Any term, mechanism, or decision an action leans on gets its own Key Concept
+  subsection, and the action links to it with a same-file heading link
+  (Obsidian form: `[[#Heading Text|display text]]`).
+- Push all explanation into Key Concepts — never pad the Next Actions list itself.
+
+**Key Concepts section:**
+- One subsection per term, mechanism, or decision a task links to — nothing the
+  tasks don't reach for.
+- A concept that is a *decision* lays out the options and their trade-offs (a
+  short comparison table works well), then states the recommendation.
+- A concept that touches code includes a source link (with line numbers) and a
+  short code sample, per the Code Evidence Requirement above.
+
+**Background section:**
+- This is the running log, not static context: decisions already made,
+  progress, dead-ends. It is what lets the project be resumed later. Keep it
+  distinct from "What we know" (which is the current evidenced picture).
+
+**Final Compliance Check (required before finishing):**
+- "Other Lists" / @waiting / @backlog / @someday are NOT present.
+- Problem leads with **Problem:** + **Done looks like:**, then the What we know /
+  What we think `###` subsections.
+- Next Actions has NO intro line — just the `@urgent` checklist; every item is
+  one line and links to a Key Concept (unless trivially self-explanatory).
+- Each Key Concept that touches code has both a link and a short code sample.
+- Related Topics links are all concrete and valid.
 -->
 
 # {{title}}
 
-**@urgent** tasks:
+## Problem
 
-- [ ] Task 1
-- [ ] Task 2
+**Problem:** State the problem motivating this project in one line.
 
-## Context
+**Done looks like:** State the concrete end-state you're aiming for in one line.
 
-What is the issue that we're seeing that is motivating this decision or change?
+### What we know
 
-## Other Lists
+- Confirmed facts and current state, with evidence (link code lines, logs, or command output rather than asserting).
 
-These hold my other actions so I can know they're recorded but "forget" about them to reduce cognitive load.
+### What we think
 
-**@waiting** for these tasks:
+- The chosen plan, or hypotheses if anything is still open — each with its reasoning. Mark unconfirmed items as such.
 
-- [ ] Waiting task 1
+## Next Actions
 
-**@backlog** tasks for later:
+- [ ] First next action — see [[#Concept One|the concept]]
+- [ ] Second next action — see [[#Concept Two|the concept]]
 
-- [ ] Backlog task 1
+## Key Concepts
 
-**@someday** ideas to revisit:
+The supporting detail behind the tasks. One subsection per term, mechanism, or
+decision a task leans on, so the task list itself can stay one line per item.
+Where a task is a *decision*, lay out the options and trade-offs here.
 
-- [ ] Someday idea 1
+### Concept One
 
-## Project Purpose
+Explain the concept, mechanism, or decision a task refers to.
 
-**Why does this project matter?**
+**Code Location** (if relevant): [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
 
-Explain the motivation and value this project provides.
+### Concept Two
 
-## Desired Outcome
-
-**What does "done" look like?**
-
-Describe the concrete end result you're aiming for. Be specific.
+Explain the next one.
 
 ## Background
 
-Use this section to capture context, decisions made, or a running log of progress.
+Running breadcrumb trail: decisions already made, progress, and dead-ends — so
+the project can be picked up later without re-deriving everything.
+
+## Related Topics
+
+- Code, documentation, issue trackers, and local docs links go here.


### PR DESCRIPTION
## What

Three changes to the Diátaxis doc templates:

1. **Reshape `project.md` to a handover-style structure** (`39fb83e`)
   - Replaces the old GTD shape (`Context` / `Other Lists` / `Project Purpose` / `Desired Outcome`) with: `## Problem` (with **Problem:** / **Done looks like:** leads) → `### What we know` → `### What we think` → `## Next Actions` → `## Key Concepts` → `## Background` → `## Related Topics`.
   - `Next Actions` is a bare `@urgent` checklist — the "sparse, one line each, link to a Key Concept" rule now lives in the template's guidance metadata rather than as a body line.
   - Adds explicit `Key Concepts` guidance (a *decision* concept lays out options/trade-offs; a *code* concept needs a link + sample).

2. **Standardize the links heading to `Related Topics`** in `handover.md`, `adr.md`, `5why.md` (`4f33f1c`) — these used `References`, which didn't match `common.metadata` / `explanation.md`.

3. **Normalize `note.md` headings** (`df23867`) — Title-case `KEYPOINTS/SUMMARY/TASKS/BACKGROUND` → `Keypoints/Summary/Tasks/Background`, and rename `REFERENCES` → `Related Topics`.

## Why

- The project template now opens by **capturing thinking** (handover style) and pushes detail into **Key Concepts** (explanation style), keeping the action list sparse and skimmable.
- Every template now names its links section **`Related Topics`**, so the shared `common.metadata` linking rule ("Every reference in Related Topics must be a real link") is accurate for all templates.

## Verification

- All 7 templates now use `## Related Topics` (explanation, pr, project, handover, adr, 5why, note).
- `dia project new` scaffolds `project.md` cleanly in the new shape (`## Problem → ### What we know → ### What we think → ## Next Actions → …`), with no `@urgent` intro line in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)