### PR TITLE
Resolve env config at the CLI boundary (fix the deep-ENV-read smell)

### DIFF
--- a/lib/diataxis/cli.rb
+++ b/lib/diataxis/cli.rb
@@ -8,14 +8,18 @@ module Diataxis
   # Command Line Interface module for the Diataxis documentation framework
   # Handles parsing and routing of CLI commands to appropriate handlers
   module CLI
-    def self.run(args)
+    # The composition root: the ONLY place that reads the environment. `root`
+    # and `default_tags` default to the env vars, but callers (notably tests)
+    # can inject them explicitly to stay hermetic. Everything downstream
+    # receives the resolved values as arguments and never touches ENV.
+    def self.run(args, root: ENV.fetch('DIATAXIS_ROOT', nil), default_tags: ENV.fetch('DIATAXIS_TAGS', nil))
       return UsageDisplay.show_usage if args.empty?
 
-      options = GlobalFlagsHandler.process!(args)
+      options = GlobalFlagsHandler.process!(args, default_tags: default_tags)
 
       command = args.shift
 
-      CommandRouter.route(command, args, tags: options[:tags])
+      CommandRouter.route(command, args, tags: options[:tags], root: root)
     end
   end
 end

--- a/lib/diataxis/cli/command_handlers.rb
+++ b/lib/diataxis/cli/command_handlers.rb
@@ -9,8 +9,8 @@ require_relative '../errors'
 module Diataxis
   module CLI
     class CommandHandlers
-      def self.handle_init(args)
-        directory = args.empty? ? resolve_root_directory : File.expand_path(args[0])
+      def self.handle_init(args, root: nil)
+        directory = args.empty? ? normalize_root(root) : File.expand_path(args[0])
         Diataxis.logger.debug("Initializing Diataxis config in directory: #{directory}")
 
         validate_directory!(directory)
@@ -19,18 +19,14 @@ module Diataxis
         Config.create(directory, config)
       end
 
-      def self.handle_document(command, args, tags: [])
+      def self.handle_document(command, args, tags: [], root: nil)
         validate_document_args!(args, command)
         document_class = DocumentRegistry.lookup(command)
-        create_document_with_readme_update(args, document_class, tags: tags)
+        create_document_with_readme_update(args, document_class, tags: tags, root: root)
       end
 
-      def self.handle_update(args)
-        directory = if args.empty?
-                      resolve_root_directory
-                    else
-                      File.expand_path(args[0])
-                    end
+      def self.handle_update(args, root: nil)
+        directory = args.empty? ? normalize_root(root) : File.expand_path(args[0])
         validate_directory!(directory)
 
         Config.load(directory)
@@ -63,15 +59,17 @@ module Diataxis
         )
       end
 
-      private_class_method def self.resolve_root_directory
-        root = ENV.fetch('DIATAXIS_ROOT', nil)
-        return Dir.pwd if root.nil? || root.empty?
+      # Normalises an already-resolved root (passed down from CLI.run) into a
+      # concrete directory. Does NOT read the environment — an empty/nil root
+      # means "use the current working directory".
+      private_class_method def self.normalize_root(root)
+        return Dir.pwd if root.nil? || root.to_s.empty?
 
         File.expand_path(root)
       end
 
-      private_class_method def self.create_document_with_readme_update(args, document_class, tags: [])
-        directory = resolve_root_directory
+      private_class_method def self.create_document_with_readme_update(args, document_class, tags: [], root: nil)
+        directory = normalize_root(root)
         ensure_config_exists!(directory)
 
         title = args[1..].join(' ')

--- a/lib/diataxis/cli/command_router.rb
+++ b/lib/diataxis/cli/command_router.rb
@@ -16,28 +16,28 @@ module Diataxis
         'update' => :update
       }.freeze
 
-      def self.route(command, args, tags: [])
+      def self.route(command, args, tags: [], root: nil)
         action = BUILTIN_COMMANDS[command]
 
         if action
-          execute_builtin(action, args)
+          execute_builtin(action, args, root: root)
         elsif DocumentRegistry.lookup(command)
-          CommandHandlers.handle_document(command, args, tags: tags)
+          CommandHandlers.handle_document(command, args, tags: tags, root: root)
         else
           UsageDisplay.show_unknown_command_error(command)
         end
       end
 
-      private_class_method def self.execute_builtin(action, args)
+      private_class_method def self.execute_builtin(action, args, root: nil)
         case action
         when :version
           UsageDisplay.show_version
         when :help
           UsageDisplay.show_usage(0)
         when :init
-          CommandHandlers.handle_init(args)
+          CommandHandlers.handle_init(args, root: root)
         when :update
-          CommandHandlers.handle_update(args)
+          CommandHandlers.handle_update(args, root: root)
         end
       end
     end

--- a/lib/diataxis/cli/global_flags_handler.rb
+++ b/lib/diataxis/cli/global_flags_handler.rb
@@ -6,7 +6,10 @@ module Diataxis
   module CLI
     # Extracts global flags (--verbose, --quiet, --tag) from argv before command routing.
     class GlobalFlagsHandler
-      def self.process!(args)
+      # `default_tags` is the resolved default-tags input (a comma-separated
+      # string, e.g. from DIATAXIS_TAGS, or nil). It is passed in by the caller
+      # rather than read from ENV here, so this stays free of ambient state.
+      def self.process!(args, default_tags: nil)
         tags = []
         remaining = []
         i = 0
@@ -29,15 +32,13 @@ module Diataxis
           i += 1
         end
 
-        env_tags = parse_env_tags
-        merged = (env_tags + tags).uniq
+        merged = (parse_tags(default_tags) + tags).uniq
 
         args.replace(remaining)
         { tags: merged }
       end
 
-      private_class_method def self.parse_env_tags
-        value = ENV.fetch('DIATAXIS_TAGS', nil)
+      private_class_method def self.parse_tags(value)
         return [] if value.nil? || value.strip.empty?
 
         value.split(',').map(&:strip).reject(&:empty?)

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Diataxis do
   end
   let(:config_path) { File.join(test_dir, '.diataxis') }
 
+  # Drive the CLI with the test's root injected, so document-creating examples
+  # are hermetic regardless of any ambient DIATAXIS_ROOT / DIATAXIS_TAGS. The
+  # dedicated env-var describe blocks below instead call Diataxis::CLI.run
+  # directly, to exercise the real environment resolution.
+  def run_cli(args)
+    Diataxis::CLI.run(args, root: test_dir, default_tags: nil)
+  end
+
   before do
     # Reset logger state for clean test environment
     Diataxis::Log.reset!
@@ -46,7 +54,7 @@ RSpec.describe Diataxis do
     context 'with default configuration' do
       it 'creates documents in default locations' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Test Document'])
+          run_cli(['howto', 'new', 'Test Document'])
         end
 
         expect(File).to exist(File.join(docs_paths[:howto], 'howto_how_to_test_document.md'))
@@ -70,7 +78,7 @@ RSpec.describe Diataxis do
 
       it 'creates documents in configured locations' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Test Custom Path'])
+          run_cli(['howto', 'new', 'Test Custom Path'])
         end
 
         expect(File).to exist(File.join(custom_dir, 'howtos/howto_how_to_test_custom_path.md'))
@@ -86,7 +94,7 @@ RSpec.describe Diataxis do
 
       it 'shows clear error message' do
         Dir.chdir(test_dir) do
-          expect { Diataxis::CLI.run(['howto', 'new', 'Test Error']) }.to raise_error(JSON::ParserError)
+          expect { run_cli(['howto', 'new', 'Test Error']) }.to raise_error(JSON::ParserError)
         end
       end
     end
@@ -99,14 +107,14 @@ RSpec.describe Diataxis do
 
       it 'fails with helpful error message when creating a document' do
         Dir.chdir(test_dir) do
-          expect { Diataxis::CLI.run(['project', 'new', 'Test Project']) }
+          expect { run_cli(['project', 'new', 'Test Project']) }
             .to raise_error(Diataxis::ConfigurationError, /No \.diataxis configuration file found/)
         end
       end
 
       it 'suggests running dia init in error message' do
         Dir.chdir(test_dir) do
-          expect { Diataxis::CLI.run(%w[howto new Test]) }
+          expect { run_cli(%w[howto new Test]) }
             .to raise_error(Diataxis::ConfigurationError, /Please run 'dia init'/)
         end
       end
@@ -117,7 +125,7 @@ RSpec.describe Diataxis do
     context 'creating how-tos' do
       it 'creates how-to with correct template and updates README' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Configure System'])
+          run_cli(['howto', 'new', 'Configure System'])
         end
 
         howto_path = File.join(docs_paths[:howto], 'howto_how_to_configure_system.md')
@@ -134,7 +142,7 @@ RSpec.describe Diataxis do
     context 'creating tutorial' do
       it 'creates tutorial with correct template and updates README' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['tutorial', 'new', 'Getting Started'])
+          run_cli(['tutorial', 'new', 'Getting Started'])
         end
 
         tutorial_path = File.join(docs_paths[:tutorial], 'tutorial_getting_started.md')
@@ -151,7 +159,7 @@ RSpec.describe Diataxis do
     context 'creating ADR' do
       it 'creates ADR with correct numbering and updates README' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['adr', 'new', 'Use PostgreSQL Database'])
+          run_cli(['adr', 'new', 'Use PostgreSQL Database'])
         end
 
         adr_path = File.join(docs_paths[:adr], '0001-use-postgresql-database.md')
@@ -170,7 +178,7 @@ RSpec.describe Diataxis do
 
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['project', 'new', 'Sprint Planning'])
+          run_cli(['project', 'new', 'Sprint Planning'])
         end
       end
 
@@ -202,7 +210,7 @@ RSpec.describe Diataxis do
 
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['pr', 'new', 'Fix Login Bug'])
+          run_cli(['pr', 'new', 'Fix Login Bug'])
         end
       end
 
@@ -232,7 +240,7 @@ RSpec.describe Diataxis do
     it 'renames file and updates README when title changes' do
       Dir.chdir(test_dir) do
         # Create initial document
-        Diataxis::CLI.run(['howto', 'new', 'Original Title'])
+        run_cli(['howto', 'new', 'Original Title'])
         original_path = File.join(docs_paths[:howto], 'howto_how_to_original_title.md')
 
         # Update title
@@ -241,7 +249,7 @@ RSpec.describe Diataxis do
         File.write(original_path, new_content)
 
         # Run update
-        Diataxis::CLI.run(['update', '.'])
+        run_cli(['update', '.'])
 
         # Check results
         new_path = File.join(docs_paths[:howto], 'howto_how_to_updated_title.md')
@@ -262,7 +270,7 @@ RSpec.describe Diataxis do
 
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['explanation', 'new', 'System Architecture'])
+          run_cli(['explanation', 'new', 'System Architecture'])
         end
       end
 
@@ -305,7 +313,7 @@ RSpec.describe Diataxis do
 
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['explanation', 'new', 'Understanding Configuration Management'])
+          run_cli(['explanation', 'new', 'Understanding Configuration Management'])
         end
       end
 
@@ -325,11 +333,11 @@ RSpec.describe Diataxis do
 
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['explanation', 'new', 'System Architecture'])
+          run_cli(['explanation', 'new', 'System Architecture'])
           content = File.read(original_path)
           new_content = content.sub('# System Architecture', '# Advanced System Design')
           File.write(original_path, new_content)
-          Diataxis::CLI.run(['update', '.'])
+          run_cli(['update', '.'])
         end
       end
 
@@ -381,17 +389,19 @@ RSpec.describe Diataxis do
 
         # Create documents in both repositories
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['adr', 'new', 'Main Repo Decision'])
+          run_cli(['adr', 'new', 'Main Repo Decision'])
         end
 
+        # This document belongs to the *other* repo, so inject that root
+        # explicitly rather than the default test_dir used by run_cli.
         Dir.chdir(other_repo_dir) do
-          Diataxis::CLI.run(['adr', 'new', 'Other Repo Decision'])
+          Diataxis::CLI.run(['adr', 'new', 'Other Repo Decision'], root: other_repo_dir)
         end
       end
 
       it 'only includes documents from the current repository in README' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['update', '.'])
+          run_cli(['update', '.'])
         end
 
         readme_content = File.read(docs_paths[:readme])
@@ -410,7 +420,7 @@ RSpec.describe Diataxis do
         File.write(wrong_path_adr, "# 2. Misplaced Decision\n\nDate: 2025-03-05\n")
 
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['update', '.'])
+          run_cli(['update', '.'])
         end
 
         readme_content = File.read(docs_paths[:readme])
@@ -428,7 +438,7 @@ RSpec.describe Diataxis do
 
       it 'preserves custom content while updating document links' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Test Document'])
+          run_cli(['howto', 'new', 'Test Document'])
         end
 
         readme_content = File.read(docs_paths[:readme])
@@ -440,7 +450,7 @@ RSpec.describe Diataxis do
     context 'without existing README' do
       it 'creates new README with correct sections' do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Test Document'])
+          run_cli(['howto', 'new', 'Test Document'])
         end
 
         readme_content = File.read(docs_paths[:readme])
@@ -454,7 +464,7 @@ RSpec.describe Diataxis do
   describe 'directory handling' do
     it 'creates necessary directories when missing' do
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['howto', 'new', 'Test Document'])
+        run_cli(['howto', 'new', 'Test Document'])
       end
 
       expect(Dir).to exist(docs_paths[:docs])
@@ -466,8 +476,8 @@ RSpec.describe Diataxis do
     context 'with mixed document types' do
       before do
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Deploy Application'])
-          Diataxis::CLI.run(['adr', 'new', 'Use Docker'])
+          run_cli(['howto', 'new', 'Deploy Application'])
+          run_cli(['adr', 'new', 'Use Docker'])
           # NOTE: No tutorials or explanations created
         end
       end
@@ -496,7 +506,7 @@ RSpec.describe Diataxis do
       before do
         # Start with no tutorials
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['howto', 'new', 'Basic Guide'])
+          run_cli(['howto', 'new', 'Basic Guide'])
         end
       end
 
@@ -507,7 +517,7 @@ RSpec.describe Diataxis do
 
         # Add a tutorial
         Dir.chdir(test_dir) do
-          Diataxis::CLI.run(['tutorial', 'new', 'Getting Started'])
+          run_cli(['tutorial', 'new', 'Getting Started'])
         end
 
         readme_content = File.read(docs_paths[:readme])
@@ -660,7 +670,8 @@ RSpec.describe Diataxis do
 
     it 'creates document with YAML front matter tags from CLI flags' do
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['-t', '-jira/bolt/135', '-t', '-jira/bolt/141', 'explanation', 'new', 'Tagged Doc'])
+        Diataxis::CLI.run(['-t', '-jira/bolt/135', '-t', '-jira/bolt/141', 'explanation', 'new', 'Tagged Doc'],
+                          root: test_dir)
       end
 
       doc_path = File.join(test_dir, 'docs', 'explanation_tagged_doc.md')
@@ -675,7 +686,7 @@ RSpec.describe Diataxis do
       ENV['DIATAXIS_TAGS'] = '-env/tag1,-env/tag2'
 
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['explanation', 'new', 'Env Tagged'])
+        Diataxis::CLI.run(['explanation', 'new', 'Env Tagged'], root: test_dir)
       end
 
       doc_path = File.join(test_dir, 'docs', 'explanation_env_tagged.md')
@@ -689,7 +700,7 @@ RSpec.describe Diataxis do
       ENV['DIATAXIS_TAGS'] = '-shared,-env-only'
 
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['-t', '-shared', '-t', '-cli-only', 'howto', 'new', 'Merged Tags'])
+        Diataxis::CLI.run(['-t', '-shared', '-t', '-cli-only', 'howto', 'new', 'Merged Tags'], root: test_dir)
       end
 
       doc_path = File.join(test_dir, 'docs', 'howto_how_to_merged_tags.md')
@@ -704,7 +715,7 @@ RSpec.describe Diataxis do
       ENV.delete('DIATAXIS_TAGS')
 
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['explanation', 'new', 'No Tags'])
+        Diataxis::CLI.run(['explanation', 'new', 'No Tags'], root: test_dir)
       end
 
       doc_path = File.join(test_dir, 'docs', 'explanation_no_tags.md')
@@ -715,7 +726,7 @@ RSpec.describe Diataxis do
 
     it 'preserves leading hyphens in tag values' do
       Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['-t', '-alpha-sort-tag', 'tutorial', 'new', 'Hyphen Tags'])
+        Diataxis::CLI.run(['-t', '-alpha-sort-tag', 'tutorial', 'new', 'Hyphen Tags'], root: test_dir)
       end
 
       doc_path = File.join(test_dir, 'docs', 'tutorial_hyphen_tags.md')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,24 +17,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  # Neutralise any ambient diataxis env vars (e.g. exported in a dev shell) so
-  # the generic specs resolve documents to their temp dirs and don't pick up
-  # stray default tags. Specs that exercise these vars set them explicitly in
-  # their own examples; this only clears values leaking in from the environment.
-  config.around do |example|
-    managed = %w[DIATAXIS_ROOT DIATAXIS_TAGS]
-    saved = managed.to_h { |key| [key, ENV.fetch(key, nil)] }
-    managed.each { |key| ENV.delete(key) }
-    example.run
-  ensure
-    saved.each do |key, value|
-      if value.nil?
-        ENV.delete(key)
-      else
-        ENV[key] = value
-      end
-    end
-  end
+  # No env-var neutralisation needed here: document-creating specs inject the
+  # root explicitly via the `run_cli` helper, and the dedicated DIATAXIS_ROOT /
+  # DIATAXIS_TAGS describe blocks set those vars themselves. The core no longer
+  # reads ENV — only Diataxis::CLI.run does, at the boundary.
 
   # Clean up after tests
   config.after(:suite) do


### PR DESCRIPTION
Follow-up to #42. That PR made the **tests** hermetic with an `around` hook that cleared `DIATAXIS_ROOT` / `DIATAXIS_TAGS`. This PR removes the need for that hook by fixing the underlying design: the core no longer reads the environment at all.

## The smell

`DIATAXIS_ROOT` and `DIATAXIS_TAGS` were read **deep in the call stack** — `resolve_root_directory` inside `CommandHandlers`, `parse_env_tags` inside `GlobalFlagsHandler`. Because the core reached out to global mutable state, the only way to test it was to manipulate that same global state (the `around` hook).

## The fix — resolve at the boundary, inject downstream

- **`CLI.run`** is now the single composition root and the **only** place that reads the env, via injectable keyword args that default to it:
  ```ruby
  def self.run(args, root: ENV.fetch('DIATAXIS_ROOT', nil), default_tags: ENV.fetch('DIATAXIS_TAGS', nil))
  ```
- `root` / `tags` are threaded through `CommandRouter` into the handlers. `CommandHandlers` and `GlobalFlagsHandler` no longer touch `ENV`; `resolve_root_directory` becomes a pure `normalize_root(root)`.
- The `dia` binary is unchanged — `CLI.run(ARGV)` still resolves from the env by default.

## Tests

- Document-creating specs drive the CLI through a `run_cli` helper that injects `root: test_dir` — **hermetic by construction**, no global-state juggling.
- The dedicated `DIATAXIS_ROOT` / `DIATAXIS_TAGS` describe blocks still call `Diataxis::CLI.run` directly to exercise the real boundary resolution.
- The `around` hook is **removed**. `features/support/env.rb` is **kept** — Cucumber drives the real binary, which reads the env at its own boundary, so that clear is intrinsic (not a smell).

## Commits

1. `refactor: resolve env config at the CLI boundary, keep the core pure` (`c892c23`) — verified to pass on its own with the pre-existing specs + hook (behaviour-preserving).
2. `test: inject root via run_cli and drop the env-neutralising hook` (`01587fa`).

## Verification (with `DIATAXIS_ROOT` / `DIATAXIS_TAGS` set to throwaway values, and clean)

- RuboCop: 29 files, no offenses
- RSpec: 37 examples, 0 failures
- Cucumber: 33 scenarios, 33 passed
- No document writes leak outside the test temp dirs
- Audited: the only remaining `DIATAXIS_ROOT`/`DIATAXIS_TAGS` read in `lib/` is `cli.rb`'s `run` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)