### PR TITLE
Update Obsidian wiki-links on file rename

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,6 +74,7 @@ RSpec/SpecFilePathFormat:
     - '**/spec/routing/**/*'
     - 'spec/template_loader_spec.rb'
     - 'spec/wiki_link_updater_spec.rb'
+    - 'spec/markdown_utils_spec.rb'
 
 # Offense count: 13
 # Configuration parameters: AllowedConstants.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -73,6 +73,7 @@ RSpec/SpecFilePathFormat:
   Exclude:
     - '**/spec/routing/**/*'
     - 'spec/template_loader_spec.rb'
+    - 'spec/wiki_link_updater_spec.rb'
 
 # Offense count: 13
 # Configuration parameters: AllowedConstants.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Everyone interacting in the Diataxis project's codebases, issue trackers, chat r
 * [ADR-0014](docs/adr/0014-underscore-the-gtd-directory-for-project-files-so-they-always-live-at-the-top.md) - Underscore the gtd directory for project files so they always live at the top
 * [ADR-0015](docs/adr/0015-support-environment-variable-configuration-with-diataxis-root-and-diataxis-tags.md) - Support environment variable configuration with DIATAXIS_ROOT and DIATAXIS_TAGS
 * [ADR-0016](docs/adr/0016-replace-per-type-class-files-with-registry-dsl-and-template-method-hooks.md) - Replace per-type class files with registry DSL and template method hooks
+* [ADR-0017](docs/adr/0017-obsidian-not-github-is-now-the-primary-reading-surface.md) - Obsidian, not GitHub, is now the primary reading surface
 <!-- adrlogstop -->
 
 

--- a/docs/_gtd/project_drop_the_readme_altogether.md
+++ b/docs/_gtd/project_drop_the_readme_altogether.md
@@ -1,0 +1,62 @@
+# Drop the README altogether
+
+## Problem
+
+**Problem:** [[0017-obsidian-not-github-is-now-the-primary-reading-surface|ADR-0017]] demoted the README from "the index" to a convenience file, but left open whether `dia` should keep generating it at all.
+
+**Done looks like:** A decision recorded in a follow-up ADR — keep / make opt-in / drop — and the code, tests, and any existing READMEs brought in line with it.
+
+### What we know
+
+- The README is auto-generated and refreshed on every `dia update` and on every document creation, by `ReadmeManager` ([`lib/diataxis/readme_manager.rb`](lib/diataxis/readme_manager.rb)). Both `handle_update` and `create_document_with_readme_update` call it ([`lib/diataxis/cli/command_handlers.rb`](lib/diataxis/cli/command_handlers.rb)).
+- The README path is mandatory config: `.diataxis` carries a `"readme"` key, and `ReadmeManager#readme_path` assumes it exists.
+- Per ADR-0017 the README is no longer the discovery surface — Obsidian's graph, backlinks, and tags are — so its continued generation is now a convenience, not a requirement.
+- Removing it is reversible and low-risk: the README holds no information not derivable from the documents themselves (it is generated *from* their titles).
+
+### What we think
+
+- Leaning toward **make it opt-in** rather than an outright drop (see [[#README fate options|the options]]): it removes the GitHub-era default without throwing away the generator for anyone who still wants a flat index. Unconfirmed — the decision is the point of this project.
+
+## Next Actions
+
+- [ ] Decide the README's fate and record it in a follow-up ADR — see [[#README fate options|README fate options]]
+- [ ] Make README generation conditional so it is absent by default — see [[#Making generation optional|making generation optional]]
+- [ ] Migrate or remove existing generated READMEs — see [[#Existing READMEs|existing READMEs]]
+- [ ] Update specs and features that assume a README is always written — see [[#Test fallout|test fallout]]
+
+## Key Concepts
+
+### README fate options
+
+| Option | What it means | Cost | Keeps |
+| --- | --- | --- | --- |
+| Keep generating | Status quo, now emitting `[[wiki-links]]` per ADR-0017 | none | flat index for GitHub-era habits |
+| Make opt-in | Generate only when explicitly configured/flagged; absent by default | small (a guard + config default) | the generator, off by default |
+| Drop entirely | Remove `ReadmeManager` generation; rely on Obsidian | medium (delete code + tests) | nothing — simplest end state |
+
+Recommendation: **make it opt-in** — it honours ADR-0017's "Obsidian is primary" without deleting a still-useful tool, and is the cheapest reversible step.
+
+### Making generation optional
+
+The two call sites that trigger generation both live behind `dia`'s command handlers, so a single guard (e.g. treat a missing/empty `"readme"` config key as "don't generate") would make the README absent by default without touching `ReadmeManager` itself.
+
+**Code Location:** [`lib/diataxis/cli/command_handlers.rb`](lib/diataxis/cli/command_handlers.rb) (`handle_update`, `create_document_with_readme_update`)
+
+### Existing READMEs
+
+Vaults already carrying a generated README (this repo, and the `@INBOX` vault) need a one-time decision: leave the file as a static snapshot, or delete it. This is data, not code, so it is handled per-vault, not in the gem.
+
+### Test fallout
+
+`features/title_rename.feature` and the README assertions in the cucumber suite assume a README is always written and currently assert relative-Markdown link strings. Both the ADR-0017 wiki-link switch and any "absent by default" change will require updating these expectations.
+
+## Background
+
+- 2026-06-03 — Spun out of ADR-0017, which switched the index to wiki-links and demoted the README but explicitly deferred the question of dropping it.
+
+## Related Topics
+
+- [[0017-obsidian-not-github-is-now-the-primary-reading-surface|ADR-0017]] — the decision that created this project.
+- [[0003-auto-generate-readme-with-document-links|ADR-0003]] — superseded; originally established README auto-generation.
+- [[0006-implement-automated-readme-link-management|ADR-0006]] — superseded; the relative-Markdown link format being replaced.
+- [`lib/diataxis/readme_manager.rb`](lib/diataxis/readme_manager.rb) — the generator under discussion.

--- a/docs/adr/0003-auto-generate-readme-with-document-links.md
+++ b/docs/adr/0003-auto-generate-readme-with-document-links.md
@@ -4,7 +4,7 @@ Date: 2025-02-20
 
 ## Status
 
-Accepted
+Superseded by [ADR-0017](./0017-obsidian-not-github-is-now-the-primary-reading-surface.md)
 
 ## Context
 

--- a/docs/adr/0006-implement-automated-readme-link-management.md
+++ b/docs/adr/0006-implement-automated-readme-link-management.md
@@ -1,7 +1,7 @@
 # 6. Implement Automated README Link Management
 
 Date: 2025-03-06
-Status: Accepted
+Status: Superseded by [ADR-0017](./0017-obsidian-not-github-is-now-the-primary-reading-surface.md)
 
 ## Context
 

--- a/docs/adr/0017-obsidian-not-github-is-now-the-primary-reading-surface.md
+++ b/docs/adr/0017-obsidian-not-github-is-now-the-primary-reading-surface.md
@@ -1,0 +1,50 @@
+# 0017. Obsidian, not GitHub, is now the primary reading surface
+
+Date: 2026-06-03
+
+## Status
+
+Accepted
+
+Supersedes [ADR-0003](./0003-auto-generate-readme-with-document-links.md) and [ADR-0006](./0006-implement-automated-readme-link-management.md).
+
+## Context
+
+[ADR-0003](./0003-auto-generate-readme-with-document-links.md) and [ADR-0006](./0006-implement-automated-readme-link-management.md) were written when these documents were read primarily on GitHub. There, the auto-generated `README.md` is the landing page, and relative Markdown links (`[title](path.md)`) are the only links that render. Both ADRs treat the README as *the* discovery surface and mandate relative Markdown links to make it work.
+
+That assumption no longer holds. The vault is now read in Obsidian, whose whole value is its native machinery — `[[wiki-links]]`, backlinks, tags, and the graph view. In that world:
+
+- The README is no longer the front door; the graph and backlinks are how documents are discovered.
+- Relative Markdown links are the "old way" — they do not participate in Obsidian's link graph and are not maintained automatically when a file is renamed.
+- Wiki-links, by contrast, resolve by filename and survive moves within the vault, and are kept correct on rename by the link-updater introduced alongside this decision.
+
+The tooling has already been drifting this way: the ADR and project templates both mandate `[[wiki-links]]` for local cross-references. This ADR makes the generated index consistent with that.
+
+## Decision
+
+- The generated index uses Obsidian wiki-links — `[[explanation_advanced_system_design]]` — instead of relative Markdown links. The link target carries no `.md` extension; on-disk filenames are unchanged.
+- Obsidian (graph, backlinks, tags) is the primary navigation surface. The README is demoted from "the index" to, at most, a convenience file — it is no longer the canonical way to discover documents.
+- Whether to stop generating the README altogether is **deliberately not decided here**. It is tracked as an open project: [[project_drop_the_readme_altogether]].
+
+## Consequences
+
+### Easier
+
+- Documents are first-class in the Obsidian link graph and backlinks.
+- One linking style across the whole vault — document bodies and the index alike.
+- Renames keep the index correct for free, since wiki-links are repointed by the link-updater.
+
+### Harder
+
+- Wiki-links render as literal `[[text]]` on GitHub; the repo is no longer meant to be browsed there.
+- Existing relative Markdown links need a one-time migration to wiki-links.
+
+### Unchanged
+
+- File-on-disk names and the `*.md` extension are untouched — only link *targets* change.
+
+## Related Topics
+
+- [[0003-auto-generate-readme-with-document-links|ADR-0003]] — superseded; established the README as the discovery surface.
+- [[0006-implement-automated-readme-link-management|ADR-0006]] — superseded; mandated relative Markdown links.
+- [[project_drop_the_readme_altogether]] — open project tracking the README's fate.

--- a/features/title_rename.feature
+++ b/features/title_rename.feature
@@ -57,3 +57,24 @@ Feature: Title Change and Filename Rename
     Then the file "test_docs/README.md" should not contain "tutorial_getting_started.md"
     And the file "test_docs/README.md" should contain "tutorial_quick_start_guide.md"
     And the file "test_docs/README.md" should contain "Quick Start Guide"
+
+  Scenario: Wiki-links to a renamed file are repointed, exact matches only
+    When I run `bundle exec dia explanation new "System Architecture"`
+    Given a file named "test_docs/explanations/explanation_system_architecture.md" with:
+      """
+      # Advanced System Design
+
+      Updated content about advanced system design.
+      """
+    And a file named "test_docs/explanations/notes.md" with:
+      """
+      # Notes
+
+      See [[explanation_system_architecture]] and also
+      [[explanation_system_architecture_v2]] which must stay put.
+      """
+    When I run `bundle exec dia update .`
+    Then the exit status should be 0
+    And the file "test_docs/explanations/notes.md" should contain "[[explanation_advanced_system_design]]"
+    And the file "test_docs/explanations/notes.md" should contain "[[explanation_system_architecture_v2]]"
+    And the file "test_docs/explanations/notes.md" should not contain "[[explanation_system_architecture]]"

--- a/lib/diataxis/cli/usage_display.rb
+++ b/lib/diataxis/cli/usage_display.rb
@@ -6,9 +6,13 @@ require_relative '../document_registry'
 module Diataxis
   module CLI
     class UsageDisplay
+      # Prints output and returns; never calls exit. The process exit code is
+      # the boundary's job (exe/dia): a UsageError carries a non-zero code,
+      # while the success paths just return and let the script end with 0.
+      # Calling exit here would raise SystemExit through any in-process caller
+      # (notably the test suite, aborting it mid-run).
       def self.show_version
         puts "diataxis version #{VERSION}"
-        exit 0
       end
 
       def self.show_usage(exit_code = 1)
@@ -17,7 +21,6 @@ module Diataxis
         raise UsageError.new(usage_text.strip, exit_code) unless exit_code.zero?
 
         puts usage_text
-        exit 0
       end
 
       def self.show_unknown_command_error(command)

--- a/lib/diataxis/diataxis.rb
+++ b/lib/diataxis/diataxis.rb
@@ -7,6 +7,7 @@ require_relative 'document'
 require_relative 'document/adr'
 require_relative 'document/howto'
 require_relative 'document_types'
+require_relative 'wiki_link_updater'
 require_relative 'file_manager'
 require_relative 'readme_manager'
 

--- a/lib/diataxis/document.rb
+++ b/lib/diataxis/document.rb
@@ -33,13 +33,25 @@ module Diataxis
         File.join(config_root, type_dir, '**', "#{type_config[:prefix]}_*.md")
       end
 
+      # Turns a title into the filename slug, e.g. "How to Fly" -> "how_to_fly".
+      def slugify(text)
+        sep = type_config[:slug_separator]
+        text.downcase.gsub(/[^a-z0-9]+/, sep).gsub(/^#{Regexp.escape(sep)}|#{Regexp.escape(sep)}$/, '')
+      end
+
       def generate_filename_from_file(filepath)
         title = MarkdownUtils.extract_title(filepath)
         return nil if title.nil?
 
-        sep = type_config[:slug_separator]
-        slug = title.downcase.gsub(/[^a-z0-9]+/, sep).gsub(/^#{Regexp.escape(sep)}|#{Regexp.escape(sep)}$/, '')
-        "#{type_config[:prefix]}#{sep}#{slug}.md"
+        "#{type_config[:prefix]}#{type_config[:slug_separator]}#{slugify(title)}.md"
+      end
+
+      # True when `title` slugifies to the name the file already has. Used on
+      # rename to decide whether a wiki-link's alias was the document's title
+      # (and so should track the new title) or a deliberate custom label (left
+      # untouched). ADR overrides this because its filename carries a number.
+      def title_of_filename?(title, filename_stem)
+        filename_stem == "#{type_config[:prefix]}#{type_config[:slug_separator]}#{slugify(title)}"
       end
 
       def generate_filename_from_existing(filepath)
@@ -108,9 +120,7 @@ module Diataxis
 
     def generate_filename
       cfg = self.class.type_config
-      sep = cfg[:slug_separator]
-      slug = @title.downcase.gsub(/[^a-z0-9]+/, sep).gsub(/^#{Regexp.escape(sep)}|#{Regexp.escape(sep)}$/, '')
-      "#{cfg[:prefix]}#{sep}#{slug}.md"
+      "#{cfg[:prefix]}#{cfg[:slug_separator]}#{self.class.slugify(@title)}.md"
     end
 
     def content

--- a/lib/diataxis/document/adr.rb
+++ b/lib/diataxis/document/adr.rb
@@ -36,6 +36,13 @@ module Diataxis
       filename.match?(/^\d{4}-.*\.md$/)
     end
 
+    # ADR filenames are NNNN-slug; the number is independent of the title, so
+    # compare only the slug portion (and strip any leading "N. " from the title).
+    def self.title_of_filename?(title, filename_stem)
+      clean_title = title.sub(/^\d+\. /, '')
+      filename_stem.sub(/^\d+-/, '') == slugify(clean_title)
+    end
+
     def self.format_readme_entry(title, relative_path, filepath)
       adr_num = File.basename(filepath)[0..3]
       clean_title = title.sub(/^\d+\. /, '')

--- a/lib/diataxis/file_manager.rb
+++ b/lib/diataxis/file_manager.rb
@@ -3,10 +3,13 @@
 require 'fileutils'
 require_relative 'config'
 require_relative 'document_registry'
+require_relative 'wiki_link_updater'
 
 module Diataxis
   class FileManager
-    def self.update_filename(filepath, directory, document_type = nil)
+    # `root`, when given, is the tree whose wiki-links get repointed at the new
+    # filename after a rename.
+    def self.update_filename(filepath, directory, document_type = nil, root: nil)
       document_type ||= find_document_type_for_file(filepath)
       return filepath unless document_type
 
@@ -18,6 +21,7 @@ module Diataxis
 
       FileUtils.mv(filepath, new_filepath)
       Diataxis.logger.info "Renamed: #{filepath} -> #{new_filepath}"
+      WikiLinkUpdater.update_links(root, filepath, new_filepath, document_type: document_type) if root
       new_filepath
     end
 

--- a/lib/diataxis/readme_manager.rb
+++ b/lib/diataxis/readme_manager.rb
@@ -68,7 +68,7 @@ module Diataxis
         # Calculate relative path to maintain files in their current subdirectories
         relative_dir = File.dirname(filepath).sub(base_dir, '').sub(%r{^/}, '')
         target_dir = relative_dir.empty? ? base_dir : File.join(base_dir, relative_dir)
-        FileManager.update_filename(filepath, target_dir, doc_type)
+        FileManager.update_filename(filepath, target_dir, doc_type, root: @directory)
       end
 
       # Return the updated file paths (already sorted from the original find_files call)

--- a/lib/diataxis/wiki_link_updater.rb
+++ b/lib/diataxis/wiki_link_updater.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+
+module Diataxis
+  # Keeps Obsidian-style wiki-links ([[note]]) pointing at the right document
+  # when a file is renamed.
+  #
+  # Speed vs. precision: ripgrep does the broad, fast scan to find the *handful*
+  # of files that even mention the old name inside a wiki-link; Ruby then does
+  # the precise rewrite. The link grammar we honour is:
+  #
+  #   [[ (folder/)? NAME (.md)? (#heading | |alias)? ]]
+  #
+  # The rewrite only fires on an EXACT match of NAME, so renaming
+  # `tutorial_intro` never disturbs an unrelated `[[tutorial_intro_advanced]]`.
+  # Any folder prefix, ".md" extension, #heading or |alias is preserved.
+  module WikiLinkUpdater
+    module_function
+
+    # @param root [String] directory tree whose markdown files may hold links
+    # @param old_filepath [String] the path the renamed file used to have
+    # @param new_filepath [String] the path the renamed file now has
+    # @param document_type [Class, nil] the renamed file's document type. When
+    #   given, a wiki-link alias that was the document's *old title* is retitled
+    #   to the new title; a custom alias is always left alone. When nil, aliases
+    #   are never touched (only the link target is repointed).
+    def update_links(root, old_filepath, new_filepath, document_type: nil)
+      old_name = File.basename(old_filepath, '.md')
+      new_name = File.basename(new_filepath, '.md')
+      return if old_name == new_name
+
+      new_title = document_type ? MarkdownUtils.extract_title(new_filepath) : nil
+      pattern = link_regexp(old_name)
+      candidate_files(root, old_name).each do |file|
+        rewrite_file(file, pattern, new_name, old_name, new_title, document_type)
+      end
+    end
+
+    # A wiki-link whose target is EXACTLY old_name. The grammar is:
+    #   [[ (folder/)? NAME (.md)? (#heading)? (|alias)? ]]
+    # Heading and alias are captured separately so the alias can be retitled
+    # while the target, extension and heading are carried through untouched.
+    def link_regexp(old_name)
+      esc = Regexp.escape(old_name)
+      %r{\[\[(?<prefix>[^\[\]#|]*/)?#{esc}(?<ext>\.md)?(?<heading>\#[^\[\]|]*)?(?<aliaz>\|[^\[\]]*)?\]\]}
+    end
+
+    # The same grammar expressed as a string for ripgrep, so the candidate scan
+    # and the Ruby rewrite agree on what an exact match is.
+    def link_pattern_string(old_name)
+      esc = Regexp.escape(old_name)
+      "\\[\\[([^\\[\\]#|]*/)?#{esc}(\\.md)?(#[^\\[\\]|]*)?(\\|[^\\[\\]]*)?\\]\\]"
+    end
+
+    # Uses ripgrep (fast, exact, cross-platform) to list only the files that
+    # actually contain a matching link. Falls back to a Dir.glob scan if rg is
+    # not on PATH.
+    def candidate_files(root, old_name)
+      rg = ripgrep_path
+      return glob_markdown(root) unless rg
+
+      pattern = link_pattern_string(old_name)
+      cmd = "#{Shellwords.escape(rg)} --files-with-matches --null --no-messages " \
+            "-g '*.md' #{Shellwords.escape(pattern)} #{Shellwords.escape(root)}"
+      out = `#{cmd}`
+      out.split("\x00").reject(&:empty?)
+    end
+
+    def rewrite_file(file, pattern, new_name, old_name, new_title, document_type)
+      content = File.read(file)
+      updated = content.gsub(pattern) do
+        m = Regexp.last_match
+        aliaz = rewrite_alias(m[:aliaz], old_name, new_title, document_type)
+        "[[#{m[:prefix]}#{new_name}#{m[:ext]}#{m[:heading]}#{aliaz}]]"
+      end
+      return if updated == content
+
+      File.write(file, updated)
+      Diataxis.logger.info "Updated wiki-links in #{file}"
+    end
+
+    # Retitles an alias that was the document's old title; preserves any other
+    # alias (and the no-alias case). `alias_capture` includes the leading "|".
+    def rewrite_alias(alias_capture, old_name, new_title, document_type)
+      return nil if alias_capture.nil?
+
+      text = alias_capture[1..]
+      if new_title && document_type&.title_of_filename?(text, old_name)
+        "|#{new_title}"
+      else
+        "|#{text}"
+      end
+    end
+
+    def ripgrep_path
+      path = `command -v rg 2>/dev/null`.strip
+      path.empty? ? nil : path
+    end
+
+    def glob_markdown(root)
+      Dir.glob(File.join(root, '**', '*.md'))
+    end
+  end
+end

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -552,15 +552,18 @@ RSpec.describe Diataxis do
     end
 
     it 'shows version information' do
-      expect { Diataxis::CLI.run(['--version']) }.to raise_error(SystemExit)
-
       output = capture_stdout do
         Diataxis::CLI.run(['--version'])
-      rescue StandardError
-        nil
       end
       expect(output).to include('diataxis version')
       expect(output).to include(Diataxis::VERSION)
+    end
+
+    it 'prints usage for --help and returns without raising' do
+      output = capture_stdout do
+        expect { Diataxis::CLI.run(['--help']) }.not_to raise_error
+      end
+      expect(output).to include('Usage: diataxis [options] <command>')
     end
   end
 

--- a/spec/markdown_utils_spec.rb
+++ b/spec/markdown_utils_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'tempfile'
 
-RSpec.describe 'Diataxis::MarkdownUtils' do
+RSpec.describe Diataxis::MarkdownUtils do
   describe '.extract_title' do
     context 'when markdown file has no YAML front matter' do
       it 'extracts title from first heading' do

--- a/spec/template_loader_spec.rb
+++ b/spec/template_loader_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Diataxis::TemplateLoader do
     FileUtils.rm_rf(test_dir)
   end
 
+  # Drive the CLI with the test's root injected so document-creating examples
+  # stay hermetic regardless of any ambient DIATAXIS_ROOT / DIATAXIS_TAGS.
+  # Without this, CLI.run reads ENV['DIATAXIS_ROOT'] and writes into a dev's
+  # real vault rather than the test directory.
+  def run_cli(args)
+    Diataxis::CLI.run(args, root: test_dir, default_tags: nil)
+  end
+
   describe '.load_template' do
     let(:gem_root) { File.expand_path('..', File.dirname(__FILE__)) }
     let(:common_path) { File.join(gem_root, 'templates', 'common.metadata') }
@@ -136,9 +144,7 @@ RSpec.describe Diataxis::TemplateLoader do
 
   describe 'behavioral equivalence' do
     it 'produces explanation with common guidelines and type-specific metadata' do
-      Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['explanation', 'new', 'Test Topic'])
-      end
+      run_cli(['explanation', 'new', 'Test Topic'])
 
       doc_path = File.join(test_dir, 'docs', 'explanation_test_topic.md')
       content = File.read(doc_path)
@@ -156,9 +162,7 @@ RSpec.describe Diataxis::TemplateLoader do
     end
 
     it 'produces project with common guidelines and type-specific metadata' do
-      Dir.chdir(test_dir) do
-        Diataxis::CLI.run(['project', 'new', 'Server Migration'])
-      end
+      run_cli(['project', 'new', 'Server Migration'])
 
       doc_path = Dir.glob(File.join(test_dir, 'docs', '_gtd', 'project_*.md')).first
       content = File.read(doc_path)

--- a/spec/wiki_link_updater_spec.rb
+++ b/spec/wiki_link_updater_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe Diataxis::WikiLinkUpdater do
+  let(:root) { Dir.mktmpdir('wiki-links') }
+
+  after { FileUtils.remove_entry(root) }
+
+  # Writes a markdown file under the temp root and returns its path.
+  def write_note(name, body)
+    path = File.join(root, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, body)
+    path
+  end
+
+  # Renames old -> new (basenames) and runs the link updater over the tree.
+  # Pass document_type to enable alias retitling.
+  def rename(old_name, new_name, document_type: nil)
+    described_class.update_links(
+      root, File.join(root, old_name), File.join(root, new_name), document_type: document_type
+    )
+  end
+
+  describe '.update_links' do
+    it 'repoints a plain [[link]] to the new name' do
+      note = write_note('index.md', 'See [[tutorial_intro]] for details.')
+      rename('tutorial_intro.md', 'tutorial_getting_started.md')
+      expect(File.read(note)).to eq('See [[tutorial_getting_started]] for details.')
+    end
+
+    it 'only replaces EXACT target matches, not prefix overlaps' do
+      note = write_note('index.md', '[[tutorial_intro]] and [[tutorial_intro_advanced]]')
+      rename('tutorial_intro.md', 'tutorial_basics.md')
+      expect(File.read(note)).to eq('[[tutorial_basics]] and [[tutorial_intro_advanced]]')
+    end
+
+    it 'preserves an |alias' do
+      note = write_note('index.md', 'Read [[tutorial_intro|the intro]] first.')
+      rename('tutorial_intro.md', 'tutorial_basics.md')
+      expect(File.read(note)).to eq('Read [[tutorial_basics|the intro]] first.')
+    end
+
+    it 'preserves a #heading reference' do
+      note = write_note('index.md', 'Jump to [[tutorial_intro#Setup]].')
+      rename('tutorial_intro.md', 'tutorial_basics.md')
+      expect(File.read(note)).to eq('Jump to [[tutorial_basics#Setup]].')
+    end
+
+    it 'preserves a folder path and the .md extension' do
+      note = write_note('index.md', 'See [[tutorials/tutorial_intro.md]].')
+      rename('tutorial_intro.md', 'tutorial_basics.md')
+      expect(File.read(note)).to eq('See [[tutorials/tutorial_basics.md]].')
+    end
+
+    it 'does not match a name embedded in a longer target' do
+      note = write_note('index.md', '[[my_tutorial_intro]] stays put')
+      rename('tutorial_intro.md', 'tutorial_basics.md')
+      expect(File.read(note)).to eq('[[my_tutorial_intro]] stays put')
+    end
+
+    it 'updates every matching file across the tree' do
+      a = write_note('a.md', '[[howto_setup]]')
+      b = write_note('sub/b.md', 'again [[howto_setup]] here')
+      rename('howto_setup.md', 'howto_install.md')
+      expect(File.read(a)).to eq('[[howto_install]]')
+      expect(File.read(b)).to eq('again [[howto_install]] here')
+    end
+
+    it 'does nothing when the name is unchanged' do
+      note = write_note('index.md', '[[tutorial_intro]]')
+      rename('tutorial_intro.md', 'tutorial_intro.md')
+      expect(File.read(note)).to eq('[[tutorial_intro]]')
+    end
+  end
+
+  describe 'alias retitling (with a document type)' do
+    let(:explanation) { Diataxis::DocumentRegistry.lookup('explanation') }
+
+    # The renamed file lives at its NEW path with its NEW title, since the
+    # updater reads the new title from that file (as it does after a real mv).
+    def rename_explanation(note_body)
+      write_note('explanation_how_to_soar.md', "# How to soar\n\nbody")
+      note = write_note('index.md', note_body)
+      rename('explanation_how_to_fly.md', 'explanation_how_to_soar.md', document_type: explanation)
+      File.read(note)
+    end
+
+    it 'retitles an alias that was the old title' do
+      result = rename_explanation('See [[explanation_how_to_fly|How to fly]].')
+      expect(result).to eq('See [[explanation_how_to_soar|How to soar]].')
+    end
+
+    it 'matches the old title regardless of its casing/punctuation' do
+      result = rename_explanation('See [[explanation_how_to_fly|How To Fly!]].')
+      expect(result).to eq('See [[explanation_how_to_soar|How to soar]].')
+    end
+
+    it 'keeps a custom alias that was never the title' do
+      result = rename_explanation('See [[explanation_how_to_fly|the flying guide]].')
+      expect(result).to eq('See [[explanation_how_to_soar|the flying guide]].')
+    end
+
+    it 'retitles the alias but preserves a #heading' do
+      result = rename_explanation('Jump [[explanation_how_to_fly#Setup|How to fly]].')
+      expect(result).to eq('Jump [[explanation_how_to_soar#Setup|How to soar]].')
+    end
+
+    it 'retargets a plain link with no alias' do
+      result = rename_explanation('See [[explanation_how_to_fly]].')
+      expect(result).to eq('See [[explanation_how_to_soar]].')
+    end
+
+    it 'leaves the alias alone when no document type is given' do
+      write_note('explanation_how_to_soar.md', "# How to soar\n")
+      note = write_note('index.md', 'See [[explanation_how_to_fly|How to fly]].')
+      rename('explanation_how_to_fly.md', 'explanation_how_to_soar.md')
+      expect(File.read(note)).to eq('See [[explanation_how_to_soar|How to fly]].')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When `dia update` renames a document to match a changed title, every Obsidian `[[wiki-link]]` that pointed at the old filename now follows it automatically. Along the way this surfaced and fixed pre-existing bugs that were hiding most of the test suite and leaking test data into a developer's real vault.

## What changed

### Feature: rename-aware wiki-links (`feat:` commit)
- New `WikiLinkUpdater`: finds candidate files with **ripgrep** (fast, exact, cross-platform; falls back to `Dir.glob`), then rewrites only **EXACT** target matches — renaming `tutorial_intro` never disturbs `[[tutorial_intro_advanced]]`.
- Preserves folder paths, `.md` extensions, and `#headings`.
- **Alias handling**: an alias that was the document's *old title* is retitled to the new title; a deliberately *custom* alias is left untouched. `ADR` overrides the title check because its filename carries a number prefix.
- `Document` gains a reusable `slugify` and an overridable `title_of_filename?`, DRYing previously duplicated slug logic.

### Fix: CLI no longer calls `exit` (`fix:` commit)
`UsageDisplay` called `exit 0` on the `--version`/`--help` success paths. `exit` raises `SystemExit` (not a `StandardError`), so the `--version` spec let it escape and **ended the test run after `diataxis_spec`, silently skipping every later spec file**. A library shouldn't call `exit` — the `exe/dia` boundary already owns exit codes — so the redundant calls are removed.

### Fix: `markdown_utils_spec` actually runs now (`fix:` commit)
With the suite un-poisoned, `markdown_utils_spec` failed **15/15**: it used `RSpec.describe '...'` (a string), so `described_class` was `nil`. Switched to the constant (matching the other specs).

### Fix: `template_loader_spec` is hermetic (`fix:` commit)
Two examples called `Diataxis::CLI.run([...])` without injecting a root, so they honoured the ambient `DIATAXIS_ROOT` and wrote documents (and regenerated a README) into a developer's real Obsidian vault. Now driven through a `run_cli(root: test_dir)` helper, mirroring `diataxis_spec`. Verified hermetic: with a hostile `DIATAXIS_ROOT` set, the full suite passes and writes **zero** files into it.

### Docs: ADR-0017 (`docs:` commit)
Records the decision driving this work — **Obsidian, not GitHub, is now the primary reading surface** — supersedes ADR-0003 and ADR-0006, and defers the README's ultimate fate to a tracked project doc.

## Impact on the test suite
`bundle exec rake` (CI) went from silently running **37** examples to **92, 0 failures** — three spec files (`markdown_utils`, `template_loader`, `wiki_link_updater`) now actually execute, and the suite is provably hermetic. Cucumber: 34 scenarios pass. Rubocop: clean.

## Not included (intentionally deferred)
- Switching the generated README index itself from `[title](path.md)` to `[[wiki-links]]` (the code half of ADR-0017) — tracked separately.
- Whether to stop generating the README at all — tracked in `project_drop_the_readme_altogether`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)