### PR TITLE
Add --stdout flag to print a template instead of writing a file

### DIFF
--- a/lib/diataxis/cli.rb
+++ b/lib/diataxis/cli.rb
@@ -19,7 +19,7 @@ module Diataxis
 
       command = args.shift
 
-      CommandRouter.route(command, args, tags: options[:tags], root: root)
+      CommandRouter.route(command, args, tags: options[:tags], root: root, stdout: options[:stdout])
     end
   end
 end

--- a/lib/diataxis/cli/command_handlers.rb
+++ b/lib/diataxis/cli/command_handlers.rb
@@ -19,10 +19,14 @@ module Diataxis
         Config.create(directory, config)
       end
 
-      def self.handle_document(command, args, tags: [], root: nil)
+      def self.handle_document(command, args, tags: [], root: nil, stdout: false)
         validate_document_args!(args, command)
         document_class = DocumentRegistry.lookup(command)
-        create_document_with_readme_update(args, document_class, tags: tags, root: root)
+        if stdout
+          print_document(args, document_class, tags: tags)
+        else
+          create_document_with_readme_update(args, document_class, tags: tags, root: root)
+        end
       end
 
       def self.handle_update(args, root: nil)
@@ -66,6 +70,14 @@ module Diataxis
         return Dir.pwd if root.nil? || root.to_s.empty?
 
         File.expand_path(root)
+      end
+
+      # Renders the document template to stdout instead of writing a file.
+      # Needs no config and creates nothing on disk (see Document#render and the
+      # `preview:` flag): handy for piping a fresh template into another tool.
+      private_class_method def self.print_document(args, document_class, tags: [])
+        title = args[1..].join(' ')
+        puts document_class.new(title, tags: tags, preview: true).render
       end
 
       private_class_method def self.create_document_with_readme_update(args, document_class, tags: [], root: nil)

--- a/lib/diataxis/cli/command_router.rb
+++ b/lib/diataxis/cli/command_router.rb
@@ -16,13 +16,13 @@ module Diataxis
         'update' => :update
       }.freeze
 
-      def self.route(command, args, tags: [], root: nil)
+      def self.route(command, args, tags: [], root: nil, stdout: false)
         action = BUILTIN_COMMANDS[command]
 
         if action
           execute_builtin(action, args, root: root)
         elsif DocumentRegistry.lookup(command)
-          CommandHandlers.handle_document(command, args, tags: tags, root: root)
+          CommandHandlers.handle_document(command, args, tags: tags, root: root, stdout: stdout)
         else
           UsageDisplay.show_unknown_command_error(command)
         end

--- a/lib/diataxis/cli/global_flags_handler.rb
+++ b/lib/diataxis/cli/global_flags_handler.rb
@@ -12,6 +12,7 @@ module Diataxis
       def self.process!(args, default_tags: nil)
         tags = []
         remaining = []
+        to_stdout = false
         i = 0
 
         while i < args.length
@@ -26,6 +27,8 @@ module Diataxis
             tags << args[i] if i < args.length
           when /\A--tags?=(.*)\z/
             tags << Regexp.last_match(1) unless Regexp.last_match(1).empty?
+          when '--stdout'
+            to_stdout = true
           else
             remaining << args[i]
           end
@@ -35,7 +38,7 @@ module Diataxis
         merged = (parse_tags(default_tags) + tags).uniq
 
         args.replace(remaining)
-        { tags: merged }
+        { tags: merged, stdout: to_stdout }
       end
 
       private_class_method def self.parse_tags(value)

--- a/lib/diataxis/cli/usage_display.rb
+++ b/lib/diataxis/cli/usage_display.rb
@@ -39,6 +39,7 @@ module Diataxis
             --verbose, -V             - Enable verbose output (debug level)
             --quiet, -q               - Suppress informational output (warnings only)
             --tag, -t <tag>           - Add a tag to YAML front matter (repeatable)
+            --stdout                  - Print the document to stdout instead of writing a file
             --version, -v             - Show version number
             --help, -h                - Show this help message
 

--- a/lib/diataxis/document.rb
+++ b/lib/diataxis/document.rb
@@ -86,10 +86,13 @@ module Diataxis
       end
     end
 
-    def initialize(title, directory = '.', tags: [])
+    # `preview: true` builds a document for rendering only (see #render): it
+    # skips get_configured_directory so nothing is read from or written to disk
+    # (no config lookup, no mkdir). Used by the `--stdout` flag.
+    def initialize(title, directory = '.', tags: [], preview: false)
       @title = customize_title(title)
       @tags = tags
-      @directory = get_configured_directory(directory)
+      @directory = preview ? directory : get_configured_directory(directory)
       @filename = File.join(@directory, generate_filename)
       custom = customize_filename(@title, @directory)
       @filename = custom if custom
@@ -98,6 +101,13 @@ module Diataxis
     def create
       File.write(@filename, content)
       Diataxis.logger.info "Created new #{type}: #{@filename}"
+    end
+
+    # Returns the rendered template as a string without touching the
+    # filesystem. Pair with `preview: true` so construction stays side-effect
+    # free. Used by the `--stdout` flag to dump a template to standard output.
+    def render
+      content
     end
 
     protected

--- a/lib/diataxis/document/howto.rb
+++ b/lib/diataxis/document/howto.rb
@@ -16,9 +16,11 @@ module Diataxis
       section_tag: 'howto'
     )
 
-    def initialize(title, directory = '.', tags: [])
-      validated = validate_title(title)
-      super(validated, directory, tags: tags)
+    # Only intercepts the title (to rewrite it into "How to ..."); every other
+    # positional/keyword argument is forwarded to Document#initialize verbatim,
+    # so new base keywords (e.g. preview:) work here without changes.
+    def initialize(title, *args, **kwargs)
+      super(validate_title(title), *args, **kwargs)
     end
 
     private

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -565,6 +565,51 @@ RSpec.describe Diataxis do
       end
       expect(output).to include('Usage: diataxis [options] <command>')
     end
+
+    it 'lists the --stdout flag in the help text' do
+      Diataxis::CLI.run([])
+    rescue Diataxis::UsageError => e
+      expect(e.usage_message).to include('--stdout')
+    end
+  end
+
+  describe '--stdout flag' do
+    it 'prints the rendered template to stdout without writing a file' do
+      output = capture_stdout do
+        Dir.chdir(test_dir) { run_cli(['howto', 'new', 'Stdout Demo', '--stdout']) }
+      end
+
+      expect(output.downcase).to include('# how to stdout demo')
+      expect(File).not_to exist(File.join(docs_paths[:howto], 'howto_how_to_stdout_demo.md'))
+    end
+
+    it 'does not create or update the README' do
+      FileUtils.rm_f(docs_paths[:readme])
+
+      capture_stdout do
+        Dir.chdir(test_dir) { run_cli(['explanation', 'new', 'No Side Effects', '--stdout']) }
+      end
+
+      expect(File).not_to exist(docs_paths[:readme])
+    end
+
+    it 'prepends tags to the printed template' do
+      output = capture_stdout do
+        Dir.chdir(test_dir) { run_cli(['explanation', 'new', 'Tagged', '--stdout', '--tag', '-foo']) }
+      end
+
+      expect(output).to include("---\ntags:\n  - -foo\n---")
+    end
+
+    it 'works without a .diataxis config file present' do
+      FileUtils.rm_f(config_path)
+
+      output = capture_stdout do
+        Dir.chdir(test_dir) { run_cli(['explanation', 'new', 'No Config Needed', '--stdout']) }
+      end
+
+      expect(output).to include('# No Config Needed')
+    end
   end
 
   describe 'DIATAXIS_ROOT environment variable' do


### PR DESCRIPTION
## What

Adds a `--stdout` global flag so a Diátaxis template can be dumped to standard output instead of written to a file:

```
dia explanation new 'How to fly' --stdout
```

This is handy for piping a fresh template straight into another tool — e.g. injecting it into an AI discussion — without creating a doc on disk.

## Behaviour

Works for every document type (`howto`, `tutorial`, `explanation`, `adr`, `project`, `pr`), respects `--tag`, and preserves type-specific logic (HowTo title rewriting, ADR number/status injection, tag front matter).

Crucially, `--stdout` has **no filesystem side effects**:
- no `.diataxis` config required
- no directories created
- no file written
- README left untouched

## How it works

The flag flows through the existing options pipeline rather than special-casing the parser:

- `cli/global_flags_handler.rb` — parses `--stdout` (anywhere in argv), returns `stdout:` alongside `tags:`.
- `cli.rb` → `cli/command_router.rb` → `cli/command_handlers.rb` — thread `stdout:` to a new `print_document` helper.
- `document.rb` — adds a `preview:` constructor flag that skips `get_configured_directory` (the only step that reads config / creates dirs) plus a public `render` method returning the template string.
- `cli/usage_display.rb` — documents the flag in the help text.

A separate prep commit refactors `HowTo#initialize` (the only subclass overriding `initialize`) to forward `*args`/`**kwargs` generically, so it intercepts only the title and won't need editing when the base gains future keywords.

## Testing

- 4 new RSpec examples: prints to stdout + writes no file, leaves README untouched, prepends `--tag` front matter, works with no `.diataxis` present.
- Full suite green: 97 RSpec examples, 236 Cucumber steps, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)