### PR TITLE
Require commit-pinned permalinks for code links (not blob/main)

### DIFF
--- a/templates/common.metadata
+++ b/templates/common.metadata
@@ -22,7 +22,7 @@
 
 **Linking Rules:**
 - Every reference in Related Topics must be a real link (no placeholder bullets).
-- **Code**: Link to GitHub with line numbers: [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123).
+- **Code**: Link to GitHub with a **permalink** — a commit-SHA-pinned URL with line numbers, NOT a `blob/main` branch URL: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123). Use the full 40-char SHA (or at least the abbreviated one). Permalinks are mandatory because branch URLs silently drift to the wrong lines as the file changes; a SHA pin always points at the code as it was when you wrote about it. (On GitHub press `y` to convert a branch URL to a permalink.)
 - **Commits**: Link to the actual commit: [`short-sha`](https://github.com/org/repo/commit/full-sha). In PR descriptions, each change section must include a commit link so reviewers can navigate directly to the diff.
 - **Docs**: Link to official documentation pages.
 - **Local**: Link to local docs with Obsidian-style wiki links: `[[doc-filename]]` or `[[doc-filename|display text]]`. Use the filename without the `.md` extension. Wiki links resolve by filename, so they survive file moves within the vault.

--- a/templates/explanation/explanation.md
+++ b/templates/explanation/explanation.md
@@ -44,13 +44,13 @@ The problem that set up this investigation (keep it brief — this is context, n
 
 Explain the first key concept...
 
-**Code Location** (if relevant): Link to source code using format [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
+**Code Location** (if relevant): permalink to source — commit-SHA-pinned, not `blob/main`: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
 ### Concept 2
 
 Explain the second key concept...
 
-**Code Location** (if relevant): Link to source code using format [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
+**Code Location** (if relevant): permalink to source — commit-SHA-pinned, not `blob/main`: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
 ## Related Topics
 

--- a/templates/explanation/pr.md
+++ b/templates/explanation/pr.md
@@ -58,7 +58,7 @@ Explain the context: why this work was needed, what the current state is, and wh
 
 Explain what was broken or needed. Show the problematic code or behaviour.
 
-**Code Location**: [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
+**Code Location**: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
 ```ruby
 # Show the problematic code or behaviour
@@ -70,7 +70,7 @@ Explain what was broken or needed. Show the problematic code or behaviour.
 
 Explain what was done to solve it.
 
-**Code Location**: [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
+**Code Location**: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
 ```ruby
 # Show the fix

--- a/templates/references/project.md
+++ b/templates/references/project.md
@@ -127,7 +127,7 @@ Where a task is a *decision*, lay out the options and trade-offs here.
 
 Explain the concept, mechanism, or decision a task refers to.
 
-**Code Location** (if relevant): [`filename:line`](https://github.com/org/repo/blob/main/path/file.rb#L123)
+**Code Location** (if relevant): [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
 ### Concept Two
 


### PR DESCRIPTION
## Why

The templates' Linking Rules told authors to link code with `blob/main` **branch** URLs. Branch URLs are not stable: as a file changes, the `#L123` anchor drifts and the link silently points at the wrong code. A **commit-SHA permalink** always resolves to the code exactly as it was when the reference was written — which is what a captured doc needs.

```mermaid
flowchart TD
    A[Code reference in a doc] --> B{Link form?}
    B -->|"blob/main#L123 (branch)"| C[File changes over time]
    C --> D[Line 123 now points at the WRONG code - silent drift]
    B -->|"blob/SHA#L123 (permalink)"| E[Pinned to the commit]
    E --> F[Always resolves to the intended lines]
```

## What changed

- **`templates/common.metadata`** — the shared Linking Rules now mandate a commit-SHA permalink (with the `y`-on-GitHub tip), explaining why branch URLs drift.
- **`templates/explanation/explanation.md`**, **`templates/references/project.md`**, **`templates/explanation/pr.md`** — the `Code Location` examples updated from `blob/main` to `blob/<commit-sha>`.

Since every template embeds `common.metadata`, the rule now propagates to all generated docs.

## Effect

Future dia-generated explanations, projects, and PRs will reference code with stable permalinks by default — no more silently-drifting line links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)