### PR TITLE
Add cheatsheet document type

### DIFF
--- a/lib/diataxis/document_types.rb
+++ b/lib/diataxis/document_types.rb
@@ -97,5 +97,15 @@ module Diataxis
       template: 'howto',
       section_tag: 'howto'
     )
+
+    r.register(
+      command: 'cheatsheet',
+      prefix: 'cheatsheet',
+      category: 'references',
+      config_key: 'cheatsheets',
+      readme_section: 'Cheatsheets',
+      template: 'cheatsheet',
+      section_tag: 'cheatsheet'
+    )
   end
 end

--- a/templates/references/cheatsheet.md
+++ b/templates/references/cheatsheet.md
@@ -17,13 +17,14 @@ The reader is mid-task and scanning for the right command — not learning, not 
 - Architecture or design rationale — link to an explanation doc instead.
 
 **Format rules (strict):**
-- H1: `# {{Tool/Topic}} Cheatsheet` — tool name + "Cheatsheet", nothing else.
+- H1 body placeholder is `# {{title}}` — when populating, make the title `# <Tool Name> Cheatsheet` (append "Cheatsheet").
 - One-sentence subtitle immediately below H1 — the "what this tool does in a nutshell".
-- H2: topic areas (e.g. Installation, Configuration, Common Patterns, Gotchas).
-- H3: subtopics within an area when a section gets long.
+- Section order: Quick Reference table → topic H2 sections → `## Gotchas` → `## Related Topics`.
+- H2: topic areas (e.g. Setup, Configuration, Common Patterns). H3 for sub-areas within a long section.
 - Code blocks: annotate with short inline `#` comments — not paragraphs above or below.
-- Tables: use for any option/key/value reference that has 3+ rows.
+- Tables: use for any option/key/value reference that has 3+ rows (flags, profiles, operation/meaning combos).
 - No numbered lists — bullets only, for easy reordering.
+- Keep prose to a single lead line per section at most; anything longer belongs in a linked explanation doc.
 
 **Linking rules:**
 - Add `> 📖 **Deeper dive:** [[explanation_...]]` as a one-line callout above any section
@@ -76,16 +77,6 @@ command --flag arg2  # what it does
 
 ```bash
 command arg          # what it does
-```
-
-## Common Patterns
-
-```bash
-# Pattern: {{description}}
-command
-
-# Pattern: {{description}}
-command
 ```
 
 ## Gotchas

--- a/templates/references/cheatsheet.md
+++ b/templates/references/cheatsheet.md
@@ -1,0 +1,98 @@
+<!--
+# Common Guidelines
+{{common.metadata}}
+
+**Purpose:** Operational "glance-and-go" reference. Holds ALL commands for the tool/topic.
+The reader is mid-task and scanning for the right command — not learning, not reading for context.
+
+**What belongs here:**
+- Commands, flags, and YAML/config snippets with short inline comments.
+- Tables for option/flag/value lookup grids.
+- One-liner "Gotchas" for non-obvious behaviour that bites people at the command line.
+- Callout links to explanation or how-to docs for anything that needs more than one line of prose.
+
+**What does NOT belong here:**
+- Multi-paragraph explanations — link to an explanation doc instead.
+- Step-by-step procedures — link to a how-to doc instead.
+- Architecture or design rationale — link to an explanation doc instead.
+
+**Format rules (strict):**
+- H1: `# {{Tool/Topic}} Cheatsheet` — tool name + "Cheatsheet", nothing else.
+- One-sentence subtitle immediately below H1 — the "what this tool does in a nutshell".
+- H2: topic areas (e.g. Installation, Configuration, Common Patterns, Gotchas).
+- H3: subtopics within an area when a section gets long.
+- Code blocks: annotate with short inline `#` comments — not paragraphs above or below.
+- Tables: use for any option/key/value reference that has 3+ rows.
+- No numbered lists — bullets only, for easy reordering.
+
+**Linking rules:**
+- Add `> 📖 **Deeper dive:** [[explanation_...]]` as a one-line callout above any section
+  where a vault explanation doc exists. One line only — do not describe the doc inline.
+- Related Topics at the bottom: Obsidian wiki-links `[[filename]]` for vault docs,
+  plain markdown links for external URLs. No placeholder bullets — omit rather than fake.
+
+**Placeholder rules:**
+- Replace every `{{placeholder}}` with topic-specific text before finishing.
+- Replace generic section headings (`## Section One`) with real topic names.
+- Remove any section that has no content for this topic.
+
+**Final check:**
+- H1 ends with "Cheatsheet".
+- Every section has at least one command, snippet, or table row.
+- No `{{placeholder}}` text remains.
+- No placeholder bullets in Related Topics.
+- Prose kept to one-liners; longer explanations live in linked docs.
+
+**Usage with `dia`:**
+- Run `dia cheatsheet new "<tool-name>"` — pass the tool name ONLY, without "Cheatsheet".
+  The `cheatsheet_` prefix is added to the filename automatically by `dia update`.
+  Passing "pdk-templates Cheatsheet" instead of "pdk-templates" produces the double-prefixed
+  filename `cheatsheet_pdk_templates_cheatsheet.md`.
+- After scaffolding, append " Cheatsheet" to the H1 so it reads `# <Tool Name> Cheatsheet`.
+-->
+
+# {{title}}
+
+{{one_sentence_description}}.
+
+## Quick Reference
+
+| Task | Command / Pattern |
+|---|---|
+| {{task_1}} | `{{command_1}}` |
+| {{task_2}} | `{{command_2}}` |
+| {{task_3}} | `{{command_3}}` |
+
+## {{Section One}}
+
+> 📖 **Deeper dive:** [[{{explanation_doc_filename}}]]
+
+```bash
+command --flag arg   # what it does
+command --flag arg2  # what it does
+```
+
+## {{Section Two}}
+
+```bash
+command arg          # what it does
+```
+
+## Common Patterns
+
+```bash
+# Pattern: {{description}}
+command
+
+# Pattern: {{description}}
+command
+```
+
+## Gotchas
+
+- **{{Gotcha title}}** — one-line explanation of the non-obvious behaviour.
+- **{{Gotcha title}}** — one-line explanation of the non-obvious behaviour.
+
+## Related Topics
+
+- [[{{related-vault-doc}}]] — one-line description


### PR DESCRIPTION
## Summary

- Registers a new `cheatsheet` command in `DocumentRegistry` (`lib/diataxis/document_types.rb`), category `references`, config key `cheatsheets`
- Adds `templates/references/cheatsheet.md` — an operational glance-and-go template with Quick Reference table, topic sections, Common Patterns, Gotchas, and Related Topics
- Template comment header includes format rules, linking rules, and a **Usage with `dia`** note documenting the filename-prefix behaviour

## Usage

```bash
dia cheatsheet new "pdk-templates"   # creates cheatsheet_pdk_templates.md
# then populate and append " Cheatsheet" to H1 → "# pdk-templates Cheatsheet"
```

## Test plan

- [ ] `dia cheatsheet new "<tool>"` creates `cheatsheet_<tool>.md` in docs/
- [ ] Passing the tool name only (no "Cheatsheet" suffix) avoids the `cheatsheet_<tool>_cheatsheet.md` double-prefix
- [ ] Template renders with all placeholder sections intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)