### PR TITLE
docs(project): enforce imperative verb phrase as project title

### DIFF
--- a/templates/references/project.md
+++ b/templates/references/project.md
@@ -5,6 +5,13 @@
 # Template-Specific Guidelines
 Project doc — a project is any outcome needing more than one action.
 
+**Title Rule:**
+- The `# {{title}}` heading must always be an **imperative verb phrase** — action verb first, present tense.
+- Good: `# create GSD milestone retrospective slice`, `# investigate resource_api sensitive parameters`, `# fix bolt-136 broken test`
+- Bad: `# GSD milestone`, `# resource_api`, `# dummy`
+- The verb encodes intent (what you are doing to the subject), which makes the doc self-orienting in any file list and tells an AI agent the goal immediately.
+- Pass the full verb phrase as the `dia` argument: `dia project new 'create GSD milestone retrospective slice'`
+
 **Dual audience — a human GTD doc AND an AI investigation seed.** This document
 has two readers at once, and must serve both:
 - A **human** scanning for the point, the motivation, and the next actions —


### PR DESCRIPTION
## Summary

- Adds a **Title Rule** to the project template comment block requiring the `# {{title}}` heading to always be an imperative verb phrase (action verb first, present tense)
- Provides good/bad examples so the convention is unambiguous at a glance
- Shows the correct `dia` invocation form: `dia project new 'create GSD milestone retrospective slice'`

## Why

A topic-noun title (`# resource_api`, `# GSD milestone`) tells you the subject but not the intent. An imperative phrase (`# investigate resource_api sensitive parameters`) is self-orienting in any file list and gives an AI agent handed the doc as a cold-start seed an immediate signal about what to optimise for — without reading past the first line.

## What is not changed

- `common.metadata` is untouched — the rule is project-doc-specific, not global
- The rendered output of `dia` is unchanged; `{{title}}` still substitutes the CLI argument verbatim — the discipline is enforced by the guideline, not by the tool

## Test plan

- [ ] `dia --stdout project new 'dummy'` still renders without errors and shows `# dummy` (convention enforced by guidance, not structurally)
- [ ] New rule appears in the template comment block under `# Template-Specific Guidelines`
- [ ] Good/bad examples are present and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)