### PR TITLE
Add fivewhy document type for 5 Whys root-cause analysis

### DIFF
--- a/features/document_types.feature
+++ b/features/document_types.feature
@@ -60,6 +60,13 @@ Feature: All Document Types
     And the file "test_docs/README.md" should contain "### Pull Requests"
     And the file "test_docs/README.md" should contain "Refactor Auth Module"
 
+  Scenario: Create a 5 Whys document
+    When I run `bundle exec dia fivewhy new "Deploy Script Silently Failed"`
+    Then the exit status should be 0
+    And the file "test_docs/explanations/fivewhy_deploy_script_silently_failed.md" should exist
+    And the file "test_docs/README.md" should contain "### 5 Whys"
+    And the file "test_docs/README.md" should contain "Deploy Script Silently Failed"
+
   Scenario: All 6 document types appear as separate README sections
     When I run `bundle exec dia howto new "Configure System"`
     And I run `bundle exec dia tutorial new "Getting Started"`

--- a/lib/diataxis/document_types.rb
+++ b/lib/diataxis/document_types.rb
@@ -76,6 +76,16 @@ module Diataxis
     )
 
     r.register(
+      command: 'fivewhy',
+      prefix: 'fivewhy',
+      category: 'explanation',
+      config_key: 'explanations',
+      readme_section: '5 Whys',
+      template: 'fivewhy',
+      section_tag: 'fivewhy'
+    )
+
+    r.register(
       handler: Diataxis::ADR,
       command: 'adr',
       prefix: '[0-9][0-9][0-9][0-9]',

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -244,12 +244,15 @@ RSpec.describe Diataxis do
           '## Background',
           '## Root Cause Analysis',
           '### Why 1:',
+          '**Why This Tool**:',
           '**Investigation**:',
           '**Evidence**:',
           '**Next Problem**:',
           '## Root Cause',
           '**Proof**:',
+          '**Known Issue?**:',
           '## Solution',
+          '**Source**:',
           '## Related Topics'
         ]
       end

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Diataxis do
           '## Purpose',
           '## Background',
           '## Root Cause Analysis',
-          '### Why 1:',
+          '### Why did [symptom] happen?',
           '**Why This Tool**:',
           '**Investigation**:',
           '**Evidence**:',

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -237,6 +237,22 @@ RSpec.describe Diataxis do
 
     context 'creating fivewhy' do
       let(:fivewhy_path) { File.join(docs_paths[:explanation], 'fivewhy_deploy_script_silently_failed.md') }
+      let(:fivewhy_expected_sections) do
+        [
+          '# Deploy Script Silently Failed',
+          '## Purpose',
+          '## Background',
+          '## Root Cause Analysis',
+          '### Why 1:',
+          '**Investigation**:',
+          '**Evidence**:',
+          '**Next Problem**:',
+          '## Root Cause',
+          '**Proof**:',
+          '## Solution',
+          '## Related Topics'
+        ]
+      end
 
       before do
         Dir.chdir(test_dir) do
@@ -250,19 +266,9 @@ RSpec.describe Diataxis do
 
       it 'creates fivewhy with correct template structure' do
         content = File.read(fivewhy_path)
-        expected_sections = [
-          '# Deploy Script Silently Failed',
-          '## Purpose',
-          '## Background',
-          '## Root Cause Analysis',
-          '### Why 1:',
-          '## Root Cause',
-          '## Solution',
-          '## Related Topics'
-        ]
 
         aggregate_failures do
-          expected_sections.each do |section|
+          fivewhy_expected_sections.each do |section|
             expect(content).to include(section)
           end
         end

--- a/spec/diataxis_spec.rb
+++ b/spec/diataxis_spec.rb
@@ -234,6 +234,46 @@ RSpec.describe Diataxis do
         expect(readme_content).to include('### Pull Requests')
       end
     end
+
+    context 'creating fivewhy' do
+      let(:fivewhy_path) { File.join(docs_paths[:explanation], 'fivewhy_deploy_script_silently_failed.md') }
+
+      before do
+        Dir.chdir(test_dir) do
+          run_cli(['fivewhy', 'new', 'Deploy Script Silently Failed'])
+        end
+      end
+
+      it 'creates fivewhy file with fivewhy prefix' do
+        expect(File).to exist(fivewhy_path)
+      end
+
+      it 'creates fivewhy with correct template structure' do
+        content = File.read(fivewhy_path)
+        expected_sections = [
+          '# Deploy Script Silently Failed',
+          '## Purpose',
+          '## Background',
+          '## Root Cause Analysis',
+          '### Why 1:',
+          '## Root Cause',
+          '## Solution',
+          '## Related Topics'
+        ]
+
+        aggregate_failures do
+          expected_sections.each do |section|
+            expect(content).to include(section)
+          end
+        end
+      end
+
+      it 'updates README with fivewhy link and section' do
+        readme_content = File.read(docs_paths[:readme])
+        expect(readme_content).to include('[Deploy Script Silently Failed]')
+        expect(readme_content).to include('### 5 Whys')
+      end
+    end
   end
 
   describe 'document title changes' do

--- a/templates/explanation/fivewhy.md
+++ b/templates/explanation/fivewhy.md
@@ -9,27 +9,31 @@
 - Each "Why" answer must be evidence-based (a log line, a stack trace, a reproduction step, a code reference) — not a guess. If an answer can't be verified, say so and stop; a fabricated chain produces a fabricated root cause.
 - Keep the chain causal: each Why's answer becomes the subject of the next Why. Do not jump levels or answer a different question than the one just asked.
 - Focus on process and system causes, not individual blame. "The deploy script didn't validate config before applying it" is a root cause; "Alice made a mistake" is not.
-- Five is a guideline, not a rule: stop as soon as the answer is something the team can act on, and fixing it would plausibly prevent the symptom from recurring. Continue past five if the chain is still surface-level.
+- Five is a guideline, not a rule: stop as soon as the root cause is proven (see Root Cause requirement below). Continue past five if the chain is still surface-level.
 
 **Purpose Section Requirement:**
 - Rewrite the Purpose questions so they explicitly describe what this specific investigation traces and resolves.
 - Do not keep generic Purpose questions if they are template placeholders.
 
-**Root Cause Analysis Section Requirement:**
+**Root Cause Analysis Section Requirement (transparency of method is mandatory):**
 - Number each Why sequentially (Why 1, Why 2, ...) and title each with the specific question asked, not a placeholder.
-- State the evidence for each answer before moving to the next Why.
+- Each Why must show its **Investigation**: the actual tool(s), command(s), or process used to dig into or replicate that specific question — not just the answer. Prefer one fenced shell block with a comment on each step explaining what that step checks and why. If a GUI, dashboard, or doc was consulted instead of a command, name it and link it.
+- Each Why must show its **Evidence**: the exact signal the investigation produced (a quoted log line, error message, exit code, metric, or doc excerpt) — the thing that actually justifies the Answer, not a paraphrase of it.
+- Each Why must close with **Next Problem**: one sentence naming the next question to chase. This is what the next Why heading is built from — a reader should be able to predict the next heading from this line before turning the page.
+- Do not skip Investigation/Evidence because the answer "seems obvious" — an unverified link in the chain invalidates everything built on top of it.
 - Add or remove Why steps to match the chain actually investigated — do not pad to exactly five.
 
 **Root Cause & Solution Requirement:**
-- "Root Cause" states the final, verified cause in one or two sentences — the thing that, if fixed, prevents the symptom from recurring.
+- "Root Cause" states the final cause in one or two sentences — the thing that, if fixed, prevents the symptom from recurring.
+- Root Cause requires **Proof**, not assertion: describe the specific check that confirmed this is the actual root cause and not just the deepest symptom reached (e.g. reverting the fix reproduces the original symptom, a minimal repro isolates exactly this cause, removing this factor alone stops the failure). State what was done and what result confirmed it.
 - "Solution" addresses the root cause, not the symptom described in Background. If a temporary mitigation was also applied, name it separately from the durable fix.
 
 **Final Compliance Check (required before finishing):**
 - Heading structure unchanged.
 - Placeholder text removed.
 - Purpose questions are document-specific.
-- Each Why step has evidence, not speculation.
-- Root Cause is a single verifiable statement, not another symptom.
+- Every Why has Investigation (tool/command shown), Evidence (the actual signal), and Next Problem.
+- Root Cause includes Proof, not just a claim.
 - Solution targets the root cause.
 - Related Topics links are all concrete and valid.
 - Each code reference includes both a link and an explanatory code sample.
@@ -43,8 +47,8 @@
 This document traces one problem to its root cause using the 5 Whys technique. It answers:
 
 - What was the observed symptom, and how was it detected?
-- What causal chain connects that symptom to its root cause?
-- What fixes the root cause — not just the symptom?
+- What causal chain connects that symptom to its root cause, and how was each link verified?
+- What proves this is the true root cause, and what fixes it — not just the symptom?
 
 ## Background
 
@@ -52,25 +56,58 @@ The symptom as first observed: what broke, what the impact was, and how it was n
 
 ## Root Cause Analysis
 
-> Work through the chain one verified answer at a time. Each Why's answer becomes the subject of the next Why. Stop when the answer is something actionable that would prevent recurrence — that may take fewer or more than five iterations.
+> Work through the chain one verified answer at a time. Each Why must show the tooling used to dig into it, the evidence that tooling produced, and the next problem that evidence points to. Stop when the root cause is proven — that may take fewer or more than five iterations.
 
 ### Why 1: Why did [symptom] happen?
 
-Answer, with evidence...
+**Investigation**:
+
+```bash
+# Step 1: reproduce/observe the symptom directly
+command-one --flag   # what this step checks, and why it's the right first move
+
+# Step 2: narrow down using what step 1 revealed
+command-two path/to/thing   # what signal this surfaces
+```
+
+**Evidence**: Quote the exact signal the investigation surfaced (log line, error message, exit code, metric, or doc excerpt) — the thing that actually proves the Answer below, not a paraphrase of it.
+
+**Answer**: The conclusion this evidence supports.
 
 **Code Location** (if relevant): permalink to source — commit-SHA-pinned, not `blob/main`: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
+**Next Problem**: The next question this evidence points to — this becomes the subject of Why 2.
+
 ### Why 2: Why did [answer to Why 1] happen?
 
-Answer, with evidence...
+**Investigation**:
+
+```bash
+# Step 1: dig into the specific claim from Why 1's Next Problem
+command-three ...   # what this checks
+```
+
+**Evidence**: The signal that answers this Why.
+
+**Answer**: The conclusion this evidence supports.
+
+**Next Problem**: The next question this evidence points to — this becomes the subject of Why 3.
 
 ### Why 3: Why did [answer to Why 2] happen?
 
-Answer, with evidence...
+**Investigation**: ...
+
+**Evidence**: ...
+
+**Answer**: ...
+
+**Next Problem**: ...
 
 ## Root Cause
 
 State the verified root cause in one or two sentences — the thing that, if fixed, prevents this problem from recurring.
+
+**Proof**: Describe the specific check that confirmed this is the actual root cause, not just the deepest symptom reached — what was done (reverted, isolated, reproduced from a minimal case) and what result confirmed it.
 
 ## Solution
 

--- a/templates/explanation/fivewhy.md
+++ b/templates/explanation/fivewhy.md
@@ -1,0 +1,81 @@
+<!--
+# Common Guidelines
+{{common.metadata}}
+
+# Template-Specific Guidelines
+
+**Subject Requirement (the analysis traces one problem to its root cause):**
+- This document performs a single 5 Whys investigation on one specific, well-defined problem. Do not bundle multiple unrelated symptoms into one analysis.
+- Each "Why" answer must be evidence-based (a log line, a stack trace, a reproduction step, a code reference) — not a guess. If an answer can't be verified, say so and stop; a fabricated chain produces a fabricated root cause.
+- Keep the chain causal: each Why's answer becomes the subject of the next Why. Do not jump levels or answer a different question than the one just asked.
+- Focus on process and system causes, not individual blame. "The deploy script didn't validate config before applying it" is a root cause; "Alice made a mistake" is not.
+- Five is a guideline, not a rule: stop as soon as the answer is something the team can act on, and fixing it would plausibly prevent the symptom from recurring. Continue past five if the chain is still surface-level.
+
+**Purpose Section Requirement:**
+- Rewrite the Purpose questions so they explicitly describe what this specific investigation traces and resolves.
+- Do not keep generic Purpose questions if they are template placeholders.
+
+**Root Cause Analysis Section Requirement:**
+- Number each Why sequentially (Why 1, Why 2, ...) and title each with the specific question asked, not a placeholder.
+- State the evidence for each answer before moving to the next Why.
+- Add or remove Why steps to match the chain actually investigated — do not pad to exactly five.
+
+**Root Cause & Solution Requirement:**
+- "Root Cause" states the final, verified cause in one or two sentences — the thing that, if fixed, prevents the symptom from recurring.
+- "Solution" addresses the root cause, not the symptom described in Background. If a temporary mitigation was also applied, name it separately from the durable fix.
+
+**Final Compliance Check (required before finishing):**
+- Heading structure unchanged.
+- Placeholder text removed.
+- Purpose questions are document-specific.
+- Each Why step has evidence, not speculation.
+- Root Cause is a single verifiable statement, not another symptom.
+- Solution targets the root cause.
+- Related Topics links are all concrete and valid.
+- Each code reference includes both a link and an explanatory code sample.
+- File setup instructions use "Create <file>" + code block format (no `cat > ...` heredoc flow).
+-->
+
+# {{title}}
+
+## Purpose
+
+This document traces one problem to its root cause using the 5 Whys technique. It answers:
+
+- What was the observed symptom, and how was it detected?
+- What causal chain connects that symptom to its root cause?
+- What fixes the root cause — not just the symptom?
+
+## Background
+
+The symptom as first observed: what broke, what the impact was, and how it was noticed (a failing test, an alert, a user report)...
+
+## Root Cause Analysis
+
+> Work through the chain one verified answer at a time. Each Why's answer becomes the subject of the next Why. Stop when the answer is something actionable that would prevent recurrence — that may take fewer or more than five iterations.
+
+### Why 1: Why did [symptom] happen?
+
+Answer, with evidence...
+
+**Code Location** (if relevant): permalink to source — commit-SHA-pinned, not `blob/main`: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
+
+### Why 2: Why did [answer to Why 1] happen?
+
+Answer, with evidence...
+
+### Why 3: Why did [answer to Why 2] happen?
+
+Answer, with evidence...
+
+## Root Cause
+
+State the verified root cause in one or two sentences — the thing that, if fixed, prevents this problem from recurring.
+
+## Solution
+
+Explain the fix that addresses the root cause, not just the symptom. If a temporary mitigation was applied first, name it separately from the durable fix.
+
+## Related Topics
+
+- Related concepts, how-tos, and reference docs links go here.

--- a/templates/explanation/fivewhy.md
+++ b/templates/explanation/fivewhy.md
@@ -16,11 +16,11 @@
 - Do not keep generic Purpose questions if they are template placeholders.
 
 **Root Cause Analysis Section Requirement (transparency of method is mandatory):**
-- Number each Why sequentially (Why 1, Why 2, ...) and title each with the specific question asked, not a placeholder.
+- Title each Why heading with the specific question itself (e.g. `### Why did the deploy silently skip validation?`) — do not prefix or number headings as "Why 1:", "Why 2:", etc. The question wording is the only heading; numbering adds clutter without adding information.
 - Each Why must open with **Why This Tool**: one sentence justifying the choice of tool/command *before* showing it — what it can tell you that a faster or more obvious alternative couldn't, or why it was the most direct way to answer this specific question. This is reasoning, not narration; "because it shows X and this Why is about X" beats "let's check the logs."
 - Each Why must show its **Investigation**: the actual tool(s), command(s), or process used to dig into or replicate that specific question — not just the answer. Prefer one fenced shell block with a comment on each step explaining what that step checks and why. If a GUI, dashboard, or doc was consulted instead of a command, name it and link it.
 - Each Why must show its **Evidence**: the exact signal the investigation produced (a quoted log line, error message, exit code, metric, or doc excerpt) — the thing that actually justifies the Answer, not a paraphrase of it.
-- Each Why must close with **Next Problem**: one sentence naming the next question to chase. This is what the next Why heading is built from — a reader should be able to predict the next heading from this line before turning the page.
+- Each Why must close with **Next Problem**: one sentence naming the next question to chase, worded so it can become the next Why heading verbatim — a reader should be able to predict that heading from this line before turning the page.
 - Do not skip Why This Tool/Investigation/Evidence because the answer "seems obvious" — an unverified link in the chain invalidates everything built on top of it.
 - Add or remove Why steps to match the chain actually investigated — do not pad to exactly five.
 
@@ -61,7 +61,7 @@ The symptom as first observed: what broke, what the impact was, and how it was n
 
 > Work through the chain one verified answer at a time. Each Why must justify its tool choice, show the tooling used to dig into it, the evidence that tooling produced, and the next problem that evidence points to. Stop when the root cause is proven — that may take fewer or more than five iterations.
 
-### Why 1: Why did [symptom] happen?
+### Why did [symptom] happen?
 
 **Why This Tool**: Why this specific tool/command is the right way to answer this question — what it reveals that a faster or more obvious alternative couldn't.
 
@@ -81,16 +81,16 @@ command-two path/to/thing   # what signal this surfaces
 
 **Code Location** (if relevant): permalink to source — commit-SHA-pinned, not `blob/main`: [`filename:line`](https://github.com/org/repo/blob/<commit-sha>/path/file.rb#L123)
 
-**Next Problem**: The next question this evidence points to — this becomes the subject of Why 2.
+**Next Problem**: The next question this evidence points to — worded so it becomes the next Why heading below.
 
-### Why 2: Why did [answer to Why 1] happen?
+### Why did [the prior answer] occur?
 
 **Why This Tool**: ...
 
 **Investigation**:
 
 ```bash
-# Step 1: dig into the specific claim from Why 1's Next Problem
+# Step 1: dig into the specific claim from the previous Next Problem
 command-three ...   # what this checks
 ```
 
@@ -98,19 +98,9 @@ command-three ...   # what this checks
 
 **Answer**: The conclusion this evidence supports.
 
-**Next Problem**: The next question this evidence points to — this becomes the subject of Why 3.
+**Next Problem**: The next question this evidence points to — worded so it becomes the next Why heading below.
 
-### Why 3: Why did [answer to Why 2] happen?
-
-**Why This Tool**: ...
-
-**Investigation**: ...
-
-**Evidence**: ...
-
-**Answer**: ...
-
-**Next Problem**: ...
+> Keep adding Why headings, each named after the previous Next Problem, until the root cause below is proven — this may take fewer or more than five.
 
 ## Root Cause
 

--- a/templates/explanation/fivewhy.md
+++ b/templates/explanation/fivewhy.md
@@ -17,24 +17,27 @@
 
 **Root Cause Analysis Section Requirement (transparency of method is mandatory):**
 - Number each Why sequentially (Why 1, Why 2, ...) and title each with the specific question asked, not a placeholder.
+- Each Why must open with **Why This Tool**: one sentence justifying the choice of tool/command *before* showing it — what it can tell you that a faster or more obvious alternative couldn't, or why it was the most direct way to answer this specific question. This is reasoning, not narration; "because it shows X and this Why is about X" beats "let's check the logs."
 - Each Why must show its **Investigation**: the actual tool(s), command(s), or process used to dig into or replicate that specific question — not just the answer. Prefer one fenced shell block with a comment on each step explaining what that step checks and why. If a GUI, dashboard, or doc was consulted instead of a command, name it and link it.
 - Each Why must show its **Evidence**: the exact signal the investigation produced (a quoted log line, error message, exit code, metric, or doc excerpt) — the thing that actually justifies the Answer, not a paraphrase of it.
 - Each Why must close with **Next Problem**: one sentence naming the next question to chase. This is what the next Why heading is built from — a reader should be able to predict the next heading from this line before turning the page.
-- Do not skip Investigation/Evidence because the answer "seems obvious" — an unverified link in the chain invalidates everything built on top of it.
+- Do not skip Why This Tool/Investigation/Evidence because the answer "seems obvious" — an unverified link in the chain invalidates everything built on top of it.
 - Add or remove Why steps to match the chain actually investigated — do not pad to exactly five.
 
-**Root Cause & Solution Requirement:**
+**Root Cause & Solution Requirement (provenance is mandatory, not just proof):**
 - "Root Cause" states the final cause in one or two sentences — the thing that, if fixed, prevents the symptom from recurring.
 - Root Cause requires **Proof**, not assertion: describe the specific check that confirmed this is the actual root cause and not just the deepest symptom reached (e.g. reverting the fix reproduces the original symptom, a minimal repro isolates exactly this cause, removing this factor alone stops the failure). State what was done and what result confirmed it.
+- Root Cause requires **Known Issue?**: state explicitly whether this matches a previously documented issue — link the tracker ticket, changelog entry, vendor advisory, or prior incident doc that confirms it. If no prior report exists, say so plainly ("No prior report found — this root cause is derived solely from the Investigation trail above") rather than leaving provenance ambiguous.
 - "Solution" addresses the root cause, not the symptom described in Background. If a temporary mitigation was also applied, name it separately from the durable fix.
+- Solution requires **Source**: cite where the fix came from — official docs, a changelog, a prior commit/PR, a vendor-recommended workaround — with a link. If there was no precedent and the fix was derived independently from the Root Cause, say so explicitly.
 
 **Final Compliance Check (required before finishing):**
 - Heading structure unchanged.
 - Placeholder text removed.
 - Purpose questions are document-specific.
-- Every Why has Investigation (tool/command shown), Evidence (the actual signal), and Next Problem.
-- Root Cause includes Proof, not just a claim.
-- Solution targets the root cause.
+- Every Why has Why This Tool, Investigation (tool/command shown), Evidence (the actual signal), and Next Problem.
+- Root Cause includes Proof and Known Issue?, not just a claim.
+- Solution targets the root cause and includes Source.
 - Related Topics links are all concrete and valid.
 - Each code reference includes both a link and an explanatory code sample.
 - File setup instructions use "Create <file>" + code block format (no `cat > ...` heredoc flow).
@@ -56,9 +59,11 @@ The symptom as first observed: what broke, what the impact was, and how it was n
 
 ## Root Cause Analysis
 
-> Work through the chain one verified answer at a time. Each Why must show the tooling used to dig into it, the evidence that tooling produced, and the next problem that evidence points to. Stop when the root cause is proven — that may take fewer or more than five iterations.
+> Work through the chain one verified answer at a time. Each Why must justify its tool choice, show the tooling used to dig into it, the evidence that tooling produced, and the next problem that evidence points to. Stop when the root cause is proven — that may take fewer or more than five iterations.
 
 ### Why 1: Why did [symptom] happen?
+
+**Why This Tool**: Why this specific tool/command is the right way to answer this question — what it reveals that a faster or more obvious alternative couldn't.
 
 **Investigation**:
 
@@ -80,6 +85,8 @@ command-two path/to/thing   # what signal this surfaces
 
 ### Why 2: Why did [answer to Why 1] happen?
 
+**Why This Tool**: ...
+
 **Investigation**:
 
 ```bash
@@ -95,6 +102,8 @@ command-three ...   # what this checks
 
 ### Why 3: Why did [answer to Why 2] happen?
 
+**Why This Tool**: ...
+
 **Investigation**: ...
 
 **Evidence**: ...
@@ -109,9 +118,13 @@ State the verified root cause in one or two sentences — the thing that, if fix
 
 **Proof**: Describe the specific check that confirmed this is the actual root cause, not just the deepest symptom reached — what was done (reverted, isolated, reproduced from a minimal case) and what result confirmed it.
 
+**Known Issue?**: State whether this matches a previously documented issue, with a link to the tracker ticket, changelog, vendor advisory, or prior incident doc that confirms it — or state plainly that no prior report was found and this root cause is derived solely from the Investigation trail above.
+
 ## Solution
 
 Explain the fix that addresses the root cause, not just the symptom. If a temporary mitigation was applied first, name it separately from the durable fix.
+
+**Source**: Where this fix came from — official docs, a changelog, a prior commit/PR, a vendor-recommended workaround — with a link. If there was no precedent and the fix was derived independently from the Root Cause, say so explicitly.
 
 ## Related Topics
 


### PR DESCRIPTION
## Summary
- New `dia fivewhy new "Title"` command, registered in the `explanation` category alongside `explanation` and `pr`.
- `templates/explanation/fivewhy.md` mirrors `explanation.md`'s Purpose/Background/Related Topics skeleton, but replaces "Key Concepts" with a progressive "Root Cause Analysis" section (Why 1, Why 2, ...) plus explicit Root Cause and Solution sections, so the doc ends with an actionable fix rather than a list of domain facts.
- Template guidance requires each "Why" answer to be evidence-based and causal (not speculation or individual blame), and treats five iterations as a guideline rather than a hard rule.

## Test plan
- [x] `bundle exec dia fivewhy new "..."` manually, verified file creation, content, and README section/link integration
- [x] `bundle exec rspec` — new `creating fivewhy` spec passes (pre-existing unrelated failure in `explanation document creation` predates this branch)
- [x] `bundle exec cucumber` — new `Create a 5 Whys document` scenario passes (pre-existing unrelated failure in `configuration_management.feature` predates this branch)
- [x] `bundle exec rubocop` on changed Ruby files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)