### PR TITLE
Prefer top-to-bottom flowcharts over left-to-right

### DIFF
--- a/templates/common.metadata
+++ b/templates/common.metadata
@@ -44,8 +44,10 @@
 **Diagrams (use Mermaid where it earns its place):**
 - Reach for a Mermaid diagram when a picture explains structure or flow faster than prose would — for example: how components fit together, a sequence of steps or messages, a state transition, or a before/after of a change.
 - Do NOT add a diagram just to have one. If the prose is already clear, or the relationship is trivial (two or three linear steps), skip it — a needless diagram is worse than none.
-- Prefer one focused diagram over a single sprawling one; split distinct ideas into separate diagrams.
+- Prefer one focused diagram over a single sprawling one; split distinct ideas into separate diagrams. If a diagram would otherwise grow wide (many parallel subgraphs/branches, or several loosely-related stages), first check whether splitting it into two or more smaller diagrams reads more clearly than one large one — prefer that split over cramming everything into a single diagram.
 - Use a fenced ` ```mermaid ` block. Keep node labels short and the diagram readable without zooming.
+- **Orient top-to-bottom for flowcharts and state diagrams**: use `flowchart TD` (or `TB`) and `stateDiagram-v2` default direction, not `flowchart LR`. Rendered width grows with the diagram in a top-to-bottom layout, so the reader scrolls vertically (natural) instead of horizontally (requires scrolling the page sideways, which most viewers handle poorly). Only use `LR` when the content is inherently a short horizontal sequence (2-4 nodes) that reads awkwardly stacked vertically — a rare exception, not the default. This does NOT apply to `sequenceDiagram` — participants are naturally laid out left-to-right with time flowing down, so that convention stays as-is.
+- If a flowchart has several parallel branches (e.g. multiple subgraphs or sibling paths), stack them as sequential top-to-bottom sections rather than side-by-side columns, even if that makes the diagram taller — taller is scrollable in place, wider is not. If stacking makes the single diagram feel overloaded, split it instead (see above).
 - Always keep the surrounding prose self-sufficient: the diagram should reinforce the explanation, not be the only place a key point is made (it may not render on every surface).
 
 **File Setup Formatting Rule (required for how-to steps):**


### PR DESCRIPTION
## Summary
- Mermaid flowcharts/state diagrams in generated docs default to `flowchart LR`, which renders wide and forces horizontal scrolling.
- Updates `templates/common.metadata` Diagrams section to prefer `flowchart TD`/`TB` by default, reserving `LR` for short 2-4 node sequences.
- Sequence diagrams are explicitly excluded (they're naturally left-right with time flowing down).
- Adds guidance to split an overloaded diagram into multiple focused diagrams rather than stacking everything into one wide/tall diagram.

## Test plan
- [x] Confirmed `common.metadata` is loaded live by `dia` at doc-generation time (`lib/diataxis/template_loader.rb`), so no build step is required for the change to take effect.