### PR TITLE
Fix double-nested doc paths from stray nested .diataxis config

### DIFF
--- a/lib/diataxis/cli/command_handlers.rb
+++ b/lib/diataxis/cli/command_handlers.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'fileutils'
 require_relative '../config'
 require_relative '../document_registry'
 require_relative '../readme_manager'
@@ -86,11 +85,14 @@ module Diataxis
 
         title = args[1..].join(' ')
 
-        path = Config.path_for(document_class.config_key, directory)
-        document_dir = File.join(directory, path)
-        FileUtils.mkdir_p(document_dir)
-
-        document_class.new(title, document_dir, tags: tags).create
+        # Document.new resolves the configured target directory itself (see
+        # Document#get_configured_directory) starting from `directory`. Do not
+        # pre-resolve and pass that resolved subdirectory in here instead: a
+        # second, independent config lookup starting from an already-resolved
+        # subdirectory can find a *different*, nested .diataxis file before it
+        # reaches the root one, and re-apply the relative path against that
+        # nested file's location, silently doubling it (e.g. docs/docs/...).
+        document_class.new(title, directory, tags: tags).create
 
         ReadmeManager.new(directory, DocumentRegistry.all).update
       end

--- a/lib/diataxis/document.rb
+++ b/lib/diataxis/document.rb
@@ -146,7 +146,7 @@ module Diataxis
 
     def get_configured_directory(default_dir)
       config = Config.load(default_dir)
-      configured_dir = config[self.class.type_config[:config_key]] || default_dir
+      configured_dir = config[self.class.type_config[:config_key]] || config['default']
 
       unless Pathname.new(configured_dir).absolute?
         config_dir = File.dirname(Config.find_config(default_dir) || '')


### PR DESCRIPTION
## Summary
- Document creation resolved the configured target directory twice (once in `command_handlers`, again inside `Document#initialize`). If a stray nested `.diataxis` file exists between the root and the resolved subdirectory, the second lookup would find it instead of the root config and re-apply the relative path on top, doubling path segments (e.g. `docs/docs/references/adr`).
- `command_handlers` now passes the root straight to `Document.new` so resolution happens exactly once.
- Fixed a masked fallback bug in `get_configured_directory` (`config[key] || default_dir` → `config[key] || config['default']`) that surfaced once the double-resolution was removed.

## Test plan
- [x] `bundle exec rspec` — 100 examples, 1 pre-existing unrelated failure (matches baseline)
- [x] `bundle exec cucumber` — 35/36 passing, 1 pre-existing unrelated failure (matches baseline)
- [x] `bundle exec rubocop` on changed files — no offenses
- [x] Reproduced the exact `docs/docs/references/adr` bug in an isolated scratch dir with a root `.diataxis` + nested `docs/.diataxis`, confirmed fix resolves to the correct `docs/references/adr` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)