### PR TITLE
Fix dia update silently dropping docs with a second front matter block

### DIFF
--- a/lib/diataxis/markdown_utils.rb
+++ b/lib/diataxis/markdown_utils.rb
@@ -3,19 +3,42 @@
 module Diataxis
   # Utility module for working with Markdown files
   module MarkdownUtils
-    # Extracts the first heading (title) from a markdown file, skipping YAML front matter and HTML comments
+    # Extracts the first heading (title) from a markdown file, skipping any
+    # number of leading YAML front matter and HTML comment blocks (in any
+    # order — e.g. front matter, then a comment, then a second front matter
+    # block for hand-added tags, as our own templates instruct authors to do).
     # @param filepath [String] Path to the markdown file
     # @return [String, nil] The title without the leading "# ", or nil if no title found
     def self.extract_title(filepath)
       in_yaml_front_matter = false
       in_html_comment = false
-      front_matter_count = 0
 
       File.open(filepath, 'r') do |file|
         file.each_line do |line|
           stripped_line = line.strip
 
-          # Track HTML comment blocks (<!-- ... -->)
+          if in_yaml_front_matter
+            # Only the closing delimiter ends the block; an unterminated
+            # block means we wait forever and return nil (conservative).
+            in_yaml_front_matter = false if stripped_line == '---'
+            next
+          end
+
+          if in_html_comment
+            in_html_comment = false if stripped_line.include?('-->')
+            next
+          end
+
+          # Skip blank lines between structural blocks
+          next if stripped_line.empty?
+
+          # Start of a YAML front matter block
+          if stripped_line == '---'
+            in_yaml_front_matter = true
+            next
+          end
+
+          # Start of an HTML comment block
           if stripped_line.start_with?('<!--')
             in_html_comment = true
             # Check if comment closes on same line
@@ -23,35 +46,11 @@ module Diataxis
             next
           end
 
-          if in_html_comment
-            # Check if this line closes the HTML comment
-            in_html_comment = false if stripped_line.include?('-->')
-            next
-          end
-
-          # Track YAML front matter delimiters (---)
-          if stripped_line == '---'
-            front_matter_count += 1
-            in_yaml_front_matter = front_matter_count == 1
-            next
-          end
-
-          # Skip lines while inside YAML front matter
-          next if in_yaml_front_matter
-
-          # Skip if we've only seen one delimiter (still waiting for closing delimiter)
-          next if front_matter_count == 1
-
           # Found the title heading
-          if stripped_line.start_with?('# ')
-            return stripped_line[2..].strip # Remove "# " prefix and strip whitespace
-          end
+          return stripped_line[2..].strip if stripped_line.start_with?('# ')
 
-          # Skip empty lines
-          next if stripped_line.empty?
-
-          # If we hit non-empty content that's not a heading, stop searching
-          break unless stripped_line.start_with?('#')
+          # Any other content before a heading means there's no title to find
+          break
         end
       end
 

--- a/spec/markdown_utils_spec.rb
+++ b/spec/markdown_utils_spec.rb
@@ -129,6 +129,35 @@ RSpec.describe Diataxis::MarkdownUtils do
         end
       end
 
+      it 'handles a second front matter block after an HTML comment' do
+        # Mirrors our own templates: leading front matter, then an HTML
+        # comment block, then a second front matter block for hand-added
+        # tags (per the ADR/WoW template's own instructions), then the title.
+        content = <<~MARKDOWN
+          ---
+          tags:
+            - some-tag
+          ---
+          <!--
+          # Common Guidelines
+          Some guidance text.
+          -->
+
+          ---
+          tags:
+            - -scope/implementation
+          ---
+
+          # 0001. Real Title Here
+
+          Content
+        MARKDOWN
+
+        with_temp_file(content) do |file|
+          expect(described_class.extract_title(file.path)).to eq('0001. Real Title Here')
+        end
+      end
+
       it 'handles malformed front matter (only opening delimiter)' do
         content = <<~MARKDOWN
           ---


### PR DESCRIPTION
## Summary

`dia update .` was failing to restore manually-deleted "Design Decisions" (ADR) and "Ways of Working" sections in README.md, even when the underlying documents still existed on disk.

Root cause: `MarkdownUtils.extract_title` used a `---` delimiter-counting state machine that only tolerated **one** leading YAML front matter block. Our own ADR/WoW templates (`templates/references/adr.md`, `templates/references/wow.md`) instruct authors to hand-add tags to the frontmatter via the guideline comment — and in practice this produces a **second** `---...---` block sitting after the guidelines HTML comment, before the real title. That second block confused the counter: it hit `tags:` as unstructured body content and gave up, returning `nil`.

A `nil` title makes `ReadmeManager#collect_entries` silently drop the document from its section (`entries.empty? == true`), so when a section's markers had been deleted from README.md, `dia update .` had nothing to re-add it with — even though the ADR/WoW file was right there on disk.

Reproduced and verified against a real-world file from `pe_mcp-private` that has exactly this two-frontmatter-block shape: before the fix, `extract_title` returned `nil` and `dia update .` left the deleted sections gone; after the fix, it correctly extracts the title and restores both sections.

## Fix

Rewrote `extract_title` to generically skip any number of leading YAML front matter / HTML comment blocks (in any order) instead of counting delimiters, so it tolerates however many structural blocks precede the title.

## Test plan

- [x] Added a regression spec (`spec/markdown_utils_spec.rb`) covering a second front-matter block after an HTML comment, mirroring the real-world shape
- [x] `bundle exec rspec` — 121 examples, 0 failures
- [x] `bundle exec cucumber` — same 4 pre-existing failures as on `main` (stale IDR-document-type scenarios, unrelated to this change; verified via `git stash`), no new failures
- [x] `bundle exec rubocop` — no offenses
- [x] Manually verified against the real `pe_mcp-private` repo: `dia update .` now correctly restores the "Design Decisions" and "Ways of Working" sections after they were deleted from README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)